### PR TITLE
Add SwiftUI iOS app for Iron Force upgrade calculator

### DIFF
--- a/ios/IronForceUpgradeCalculatorApp.xcodeproj/project.pbxproj
+++ b/ios/IronForceUpgradeCalculatorApp.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@ objects = {
 3C1F5D692B8A4A0E004A1A10 /* StatBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D492B8A4A0E004A1A10 /* StatBlockView.swift */; };
 3C1F5D6A2B8A4A0E004A1A10 /* CostSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4A2B8A4A0E004A1A10 /* CostSummaryView.swift */; };
 3C1F5D6B2B8A4A0E004A1A10 /* tanks.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */; };
-3C1F5D6C2B8A4A0E004A1A10 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4C2B8A4A0E004A1A10 /* Info.plist */; };
 3C1F5D762B8A4A0E004A1A10 /* CalculatorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D702B8A4A0E004A1A10 /* CalculatorServiceTests.swift */; };
 3C1F5D772B8A4A0E004A1A10 /* tanks.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */; };
 /* End PBXBuildFile section */
@@ -240,7 +239,6 @@ isa = PBXResourcesBuildPhase;
 buildActionMask = 2147483647;
 files = (
 3C1F5D6B2B8A4A0E004A1A10 /* tanks.json in Resources */,
-3C1F5D6C2B8A4A0E004A1A10 /* Info.plist in Resources */,
 );
 runOnlyForDeploymentPostprocessing = 0;
 };

--- a/ios/IronForceUpgradeCalculatorApp.xcodeproj/project.pbxproj
+++ b/ios/IronForceUpgradeCalculatorApp.xcodeproj/project.pbxproj
@@ -1,0 +1,508 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 55;
+objects = {
+
+/* Begin PBXBuildFile section */
+3C1F5D5E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D3E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.swift */; };
+3C1F5D5F2B8A4A0E004A1A10 /* Tank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D3F2B8A4A0E004A1A10 /* Tank.swift */; };
+3C1F5D602B8A4A0E004A1A10 /* UpgradeCalculatorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D402B8A4A0E004A1A10 /* UpgradeCalculatorState.swift */; };
+3C1F5D612B8A4A0E004A1A10 /* TankDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D412B8A4A0E004A1A10 /* TankDataService.swift */; };
+3C1F5D622B8A4A0E004A1A10 /* TankCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D422B8A4A0E004A1A10 /* TankCalculationService.swift */; };
+3C1F5D632B8A4A0E004A1A10 /* UserDefaultsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D432B8A4A0E004A1A10 /* UserDefaultsStore.swift */; };
+3C1F5D642B8A4A0E004A1A10 /* TankListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D442B8A4A0E004A1A10 /* TankListViewModel.swift */; };
+3C1F5D652B8A4A0E004A1A10 /* TankDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D452B8A4A0E004A1A10 /* TankDetailViewModel.swift */; };
+3C1F5D662B8A4A0E004A1A10 /* TankListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D462B8A4A0E004A1A10 /* TankListView.swift */; };
+3C1F5D672B8A4A0E004A1A10 /* TankDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D472B8A4A0E004A1A10 /* TankDetailView.swift */; };
+3C1F5D682B8A4A0E004A1A10 /* LevelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D482B8A4A0E004A1A10 /* LevelPickerSheet.swift */; };
+3C1F5D692B8A4A0E004A1A10 /* StatBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D492B8A4A0E004A1A10 /* StatBlockView.swift */; };
+3C1F5D6A2B8A4A0E004A1A10 /* CostSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4A2B8A4A0E004A1A10 /* CostSummaryView.swift */; };
+3C1F5D6B2B8A4A0E004A1A10 /* tanks.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */; };
+3C1F5D6C2B8A4A0E004A1A10 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4C2B8A4A0E004A1A10 /* Info.plist */; };
+3C1F5D762B8A4A0E004A1A10 /* CalculatorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F5D702B8A4A0E004A1A10 /* CalculatorServiceTests.swift */; };
+3C1F5D772B8A4A0E004A1A10 /* tanks.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+3C1F5D3E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IronForceUpgradeCalculatorApp.swift; sourceTree = "<group>"; };
+3C1F5D3F2B8A4A0E004A1A10 /* Tank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tank.swift; sourceTree = "<group>"; };
+3C1F5D402B8A4A0E004A1A10 /* UpgradeCalculatorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeCalculatorState.swift; sourceTree = "<group>"; };
+3C1F5D412B8A4A0E004A1A10 /* TankDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankDataService.swift; sourceTree = "<group>"; };
+3C1F5D422B8A4A0E004A1A10 /* TankCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankCalculationService.swift; sourceTree = "<group>"; };
+3C1F5D432B8A4A0E004A1A10 /* UserDefaultsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStore.swift; sourceTree = "<group>"; };
+3C1F5D442B8A4A0E004A1A10 /* TankListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankListViewModel.swift; sourceTree = "<group>"; };
+3C1F5D452B8A4A0E004A1A10 /* TankDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankDetailViewModel.swift; sourceTree = "<group>"; };
+3C1F5D462B8A4A0E004A1A10 /* TankListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankListView.swift; sourceTree = "<group>"; };
+3C1F5D472B8A4A0E004A1A10 /* TankDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TankDetailView.swift; sourceTree = "<group>"; };
+3C1F5D482B8A4A0E004A1A10 /* LevelPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelPickerSheet.swift; sourceTree = "<group>"; };
+3C1F5D492B8A4A0E004A1A10 /* StatBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatBlockView.swift; sourceTree = "<group>"; };
+3C1F5D4A2B8A4A0E004A1A10 /* CostSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostSummaryView.swift; sourceTree = "<group>"; };
+3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = tanks.json; sourceTree = "<group>"; };
+3C1F5D4C2B8A4A0E004A1A10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+3C1F5D6E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IronForceUpgradeCalculatorApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+3C1F5D6F2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IronForceUpgradeCalculatorAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+3C1F5D702B8A4A0E004A1A10 /* CalculatorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorServiceTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+3C1F5D512B8A4A0E004A1A10 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+3C1F5D732B8A4A0E004A1A10 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+3C1F5D3A2B8A4A0E004A1A10 = {
+isa = PBXGroup;
+children = (
+3C1F5D4D2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp */,
+3C1F5D6D2B8A4A0E004A1A10 /* Products */,
+);
+sourceTree = "<group>";
+};
+3C1F5D4D2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp */ = {
+isa = PBXGroup;
+children = (
+3C1F5D3E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.swift */,
+3C1F5D4E2B8A4A0E004A1A10 /* Models */,
+3C1F5D4F2B8A4A0E004A1A10 /* Services */,
+3C1F5D502B8A4A0E004A1A10 /* Persistence */,
+3C1F5D542B8A4A0E004A1A10 /* ViewModels */,
+3C1F5D562B8A4A0E004A1A10 /* Views */,
+3C1F5D552B8A4A0E004A1A10 /* Resources */,
+3C1F5D4C2B8A4A0E004A1A10 /* Info.plist */,
+3C1F5D702B8A4A0E004A1A10 /* CalculatorServiceTests.swift */,
+);
+path = IronForceUpgradeCalculatorApp;
+sourceTree = "<group>";
+};
+3C1F5D4E2B8A4A0E004A1A10 /* Models */ = {
+isa = PBXGroup;
+children = (
+3C1F5D3F2B8A4A0E004A1A10 /* Tank.swift */,
+3C1F5D402B8A4A0E004A1A10 /* UpgradeCalculatorState.swift */,
+);
+path = Models;
+sourceTree = "<group>";
+};
+3C1F5D4F2B8A4A0E004A1A10 /* Services */ = {
+isa = PBXGroup;
+children = (
+3C1F5D412B8A4A0E004A1A10 /* TankDataService.swift */,
+3C1F5D422B8A4A0E004A1A10 /* TankCalculationService.swift */,
+);
+path = Services;
+sourceTree = "<group>";
+};
+3C1F5D502B8A4A0E004A1A10 /* Persistence */ = {
+isa = PBXGroup;
+children = (
+3C1F5D432B8A4A0E004A1A10 /* UserDefaultsStore.swift */,
+);
+path = Persistence;
+sourceTree = "<group>";
+};
+3C1F5D522B8A4A0E004A1A10 /* Components */ = {
+isa = PBXGroup;
+children = (
+3C1F5D492B8A4A0E004A1A10 /* StatBlockView.swift */,
+3C1F5D4A2B8A4A0E004A1A10 /* CostSummaryView.swift */,
+);
+path = Components;
+sourceTree = "<group>";
+};
+3C1F5D552B8A4A0E004A1A10 /* Resources */ = {
+isa = PBXGroup;
+children = (
+3C1F5D4B2B8A4A0E004A1A10 /* tanks.json */,
+);
+path = Resources;
+sourceTree = "<group>";
+};
+3C1F5D542B8A4A0E004A1A10 /* ViewModels */ = {
+isa = PBXGroup;
+children = (
+3C1F5D442B8A4A0E004A1A10 /* TankListViewModel.swift */,
+3C1F5D452B8A4A0E004A1A10 /* TankDetailViewModel.swift */,
+);
+path = ViewModels;
+sourceTree = "<group>";
+};
+3C1F5D562B8A4A0E004A1A10 /* Views */ = {
+isa = PBXGroup;
+children = (
+3C1F5D462B8A4A0E004A1A10 /* TankListView.swift */,
+3C1F5D472B8A4A0E004A1A10 /* TankDetailView.swift */,
+3C1F5D482B8A4A0E004A1A10 /* LevelPickerSheet.swift */,
+3C1F5D522B8A4A0E004A1A10 /* Components */,
+);
+path = Views;
+sourceTree = "<group>";
+};
+3C1F5D6D2B8A4A0E004A1A10 /* Products */ = {
+isa = PBXGroup;
+children = (
+3C1F5D6E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.app */,
+3C1F5D6F2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorAppTests.xctest */,
+);
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+3C1F5D532B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 3C1F5D7A2B8A4A0E004A1A10 /* Build configuration list for PBXNativeTarget "IronForceUpgradeCalculatorApp" */;
+buildPhases = (
+3C1F5D4F2B8A4A0E004A1A11 /* Sources */,
+3C1F5D512B8A4A0E004A1A10 /* Frameworks */,
+3C1F5D522B8A4A0E004A1A11 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = IronForceUpgradeCalculatorApp;
+productName = IronForceUpgradeCalculatorApp;
+productReference = 3C1F5D6E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.app */;
+productType = "com.apple.product-type.application";
+};
+3C1F5D712B8A4A0E004A1A10 /* IronForceUpgradeCalculatorAppTests */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 3C1F5D7D2B8A4A0E004A1A10 /* Build configuration list for PBXNativeTarget "IronForceUpgradeCalculatorAppTests" */;
+buildPhases = (
+3C1F5D722B8A4A0E004A1A11 /* Sources */,
+3C1F5D732B8A4A0E004A1A10 /* Frameworks */,
+3C1F5D742B8A4A0E004A1A11 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+3C1F5D752B8A4A0E004A1A10 /* PBXTargetDependency */,
+);
+name = IronForceUpgradeCalculatorAppTests;
+productName = IronForceUpgradeCalculatorAppTests;
+productReference = 3C1F5D6F2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorAppTests.xctest */;
+productType = "com.apple.product-type.bundle.unit-test";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+3C1F5D3B2B8A4A0E004A1A10 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+TargetAttributes = {
+3C1F5D532B8A4A0E004A1A10 = {
+DevelopmentTeam = "";
+ProvisioningStyle = Automatic;
+};
+3C1F5D712B8A4A0E004A1A10 = {
+DevelopmentTeam = "";
+ProvisioningStyle = Automatic;
+};
+};
+};
+buildConfigurationList = 3C1F5D7E2B8A4A0E004A1A10 /* Build configuration list for PBXProject "IronForceUpgradeCalculatorApp" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+);
+mainGroup = 3C1F5D3A2B8A4A0E004A1A10;
+productRefGroup = 3C1F5D6D2B8A4A0E004A1A10 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+3C1F5D532B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp */,
+3C1F5D712B8A4A0E004A1A10 /* IronForceUpgradeCalculatorAppTests */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+3C1F5D522B8A4A0E004A1A11 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+3C1F5D6B2B8A4A0E004A1A10 /* tanks.json in Resources */,
+3C1F5D6C2B8A4A0E004A1A10 /* Info.plist in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+3C1F5D742B8A4A0E004A1A11 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+3C1F5D772B8A4A0E004A1A10 /* tanks.json in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+3C1F5D4F2B8A4A0E004A1A11 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+3C1F5D5E2B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp.swift in Sources */,
+3C1F5D5F2B8A4A0E004A1A10 /* Tank.swift in Sources */,
+3C1F5D602B8A4A0E004A1A10 /* UpgradeCalculatorState.swift in Sources */,
+3C1F5D612B8A4A0E004A1A10 /* TankDataService.swift in Sources */,
+3C1F5D622B8A4A0E004A1A10 /* TankCalculationService.swift in Sources */,
+3C1F5D632B8A4A0E004A1A10 /* UserDefaultsStore.swift in Sources */,
+3C1F5D642B8A4A0E004A1A10 /* TankListViewModel.swift in Sources */,
+3C1F5D652B8A4A0E004A1A10 /* TankDetailViewModel.swift in Sources */,
+3C1F5D662B8A4A0E004A1A10 /* TankListView.swift in Sources */,
+3C1F5D672B8A4A0E004A1A10 /* TankDetailView.swift in Sources */,
+3C1F5D682B8A4A0E004A1A10 /* LevelPickerSheet.swift in Sources */,
+3C1F5D692B8A4A0E004A1A10 /* StatBlockView.swift in Sources */,
+3C1F5D6A2B8A4A0E004A1A10 /* CostSummaryView.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+3C1F5D722B8A4A0E004A1A11 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+3C1F5D762B8A4A0E004A1A10 /* CalculatorServiceTests.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+3C1F5D752B8A4A0E004A1A10 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 3C1F5D532B8A4A0E004A1A10 /* IronForceUpgradeCalculatorApp */; targetProxy = 3C1F5D752B8A4A0E004A1A11 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+3C1F5D752B8A4A0E004A1A11 /* PBXContainerItemProxy */ = {
+isa = PBXContainerItemProxy;
+containerPortal = 3C1F5D3B2B8A4A0E004A1A10 /* Project object */;
+proxyType = 1;
+remoteGlobalIDString = 3C1F5D532B8A4A0E004A1A10;
+remoteInfo = IronForceUpgradeCalculatorApp;
+};
+/* End PBXContainerItemProxy section */
+
+/* Begin XCBuildConfiguration section */
+3C1F5D7B2B8A4A0E004A1A10 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+};
+name = Debug;
+};
+3C1F5D7C2B8A4A0E004A1A10 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+};
+name = Release;
+};
+3C1F5D7F2B8A4A0E004A1A10 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = "";
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = IronForceUpgradeCalculatorApp/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.IronForceUpgradeCalculatorApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+3C1F5D802B8A4A0E004A1A10 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = "";
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = IronForceUpgradeCalculatorApp/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.IronForceUpgradeCalculatorApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+3C1F5D812B8A4A0E004A1A10 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.IronForceUpgradeCalculatorAppTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+3C1F5D822B8A4A0E004A1A10 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.IronForceUpgradeCalculatorAppTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+3C1F5D7A2B8A4A0E004A1A10 /* Build configuration list for PBXNativeTarget "IronForceUpgradeCalculatorApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+3C1F5D7F2B8A4A0E004A1A10 /* Debug */,
+3C1F5D802B8A4A0E004A1A10 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+3C1F5D7D2B8A4A0E004A1A10 /* Build configuration list for PBXNativeTarget "IronForceUpgradeCalculatorAppTests" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+3C1F5D812B8A4A0E004A1A10 /* Debug */,
+3C1F5D822B8A4A0E004A1A10 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+3C1F5D7E2B8A4A0E004A1A10 /* Build configuration list for PBXProject "IronForceUpgradeCalculatorApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+3C1F5D7B2B8A4A0E004A1A10 /* Debug */,
+3C1F5D7C2B8A4A0E004A1A10 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+
+};
+rootObject = 3C1F5D3B2B8A4A0E004A1A10 /* Project object */;
+}

--- a/ios/IronForceUpgradeCalculatorApp/Info.plist
+++ b/ios/IronForceUpgradeCalculatorApp/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchStoryboardName</key>
+    <string></string>
+    <key>UIMainStoryboardFile</key>
+    <string></string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string></string>
+                    <key>UISceneStoryboardFile</key>
+                    <string></string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/ios/IronForceUpgradeCalculatorApp/Info.plist
+++ b/ios/IronForceUpgradeCalculatorApp/Info.plist
@@ -18,10 +18,6 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
-    <key>UILaunchStoryboardName</key>
-    <string></string>
-    <key>UIMainStoryboardFile</key>
-    <string></string>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
@@ -33,10 +29,6 @@
                 <dict>
                     <key>UISceneConfigurationName</key>
                     <string>Default Configuration</string>
-                    <key>UISceneDelegateClassName</key>
-                    <string></string>
-                    <key>UISceneStoryboardFile</key>
-                    <string></string>
                 </dict>
             </array>
         </dict>

--- a/ios/IronForceUpgradeCalculatorApp/IronForceUpgradeCalculatorApp.swift
+++ b/ios/IronForceUpgradeCalculatorApp/IronForceUpgradeCalculatorApp.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+@main
+struct IronForceUpgradeCalculatorApp: App {
+    private let dataService = TankDataService()
+    private let store = UserDefaultsStore()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                TankListView(viewModel: TankListViewModel(
+                    dataService: dataService,
+                    store: store,
+                    calculatorService: TankCalculationService()
+                ))
+            }
+        }
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Models/Tank.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Models/Tank.swift
@@ -6,7 +6,7 @@ struct TankData: Codable {
 }
 
 struct Tank: Codable, Identifiable, Hashable {
-    struct BasicInfo: Codable {
+    struct BasicInfo: Codable, Equatable, Hashable {
         let attack: Double
         let armor: Double
         let fireSpeed: Double

--- a/ios/IronForceUpgradeCalculatorApp/Models/Tank.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Models/Tank.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+struct TankData: Codable {
+    let tanks: [Tank]
+    let tankDetails: [String: TankDetail]
+}
+
+struct Tank: Codable, Identifiable, Hashable {
+    struct BasicInfo: Codable {
+        let attack: Double
+        let armor: Double
+        let fireSpeed: Double
+        let movement: Double
+    }
+
+    let name: String
+    let tier: Int
+    let price: String
+    let payType: String
+    let image: String
+    let basicInfo: BasicInfo
+
+    var id: String { name }
+
+    init(name: String, tier: Int, price: String, payType: String, image: String, basicInfo: BasicInfo) {
+        self.name = name
+        self.tier = tier
+        self.price = price
+        self.payType = payType
+        self.image = image
+        self.basicInfo = basicInfo
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        tier = try container.decode(Int.self, forKey: .tier)
+        payType = try container.decodeIfPresent(String.self, forKey: .payType) ?? ""
+        image = try container.decodeIfPresent(String.self, forKey: .image) ?? ""
+        basicInfo = try container.decode(BasicInfo.self, forKey: .basicInfo)
+
+        if let numericPrice = try? container.decode(Double.self, forKey: .price) {
+            if numericPrice.truncatingRemainder(dividingBy: 1) == 0 {
+                price = String(format: "%.0f", numericPrice)
+            } else {
+                price = String(numericPrice)
+            }
+        } else if let intPrice = try? container.decode(Int.self, forKey: .price) {
+            price = String(intPrice)
+        } else {
+            price = try container.decode(String.self, forKey: .price)
+        }
+    }
+}
+
+struct UpgradeLevel: Codable, Identifiable {
+    let level: Int
+    let attack: Double?
+    let fireSpeed: Double?
+    let armor: Double?
+    let movement: Double?
+    let time: String?
+    let calcTime: Int?
+    let price: Int?
+    let diamonds: Int?
+
+    var id: Int { level }
+}
+
+struct TankDetail: Codable {
+    let turret: [UpgradeLevel]?
+    let barrel: [UpgradeLevel]?
+    let armor: [UpgradeLevel]?
+    let engine: [UpgradeLevel]?
+    let trucks: [UpgradeLevel]?
+    let max: TankMax?
+}
+
+struct TankMax: Codable {
+    let allMax: TankStatTotals?
+    let maxMovementFireSpeed: TankStatBlock?
+}
+
+struct TankStatTotals: Codable {
+    let attack: Double?
+    let fireSpeed: Double?
+    let armor: Double?
+    let movement: Double?
+    let levels: Int?
+    let totalPrice: Double?
+    let totalTime: Double?
+    let totalDiamonds: Double?
+    let days: Double?
+}
+
+struct TankStatBlock: Codable {
+    let attack: Double?
+    let fireSpeed: Double?
+    let armor: Double?
+    let movement: Double?
+}

--- a/ios/IronForceUpgradeCalculatorApp/Models/UpgradeCalculatorState.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Models/UpgradeCalculatorState.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct UpgradeLevels: Codable, Equatable {
+    var turretLevel: Int
+    var barrelLevel: Int
+    var armorLevel: Int
+    var engineLevel: Int
+    var trucksLevel: Int
+}
+
+struct TankStats: Codable, Equatable {
+    var attack: Double
+    var fireSpeed: Double
+    var armor: Double
+    var movement: Double
+}
+
+struct UpgradeCost: Codable, Equatable {
+    var price: Int
+    var time: Int
+    var displayTime: String
+    var diamonds: Int
+}
+
+struct UpgradeCalculatorState: Codable, Equatable {
+    var version: String
+    var showTankLevels: Bool
+    var medalUsed: Bool
+    var tankLevels: UpgradeLevels
+    var currentTankLevels: UpgradeLevels
+    var tankStats: TankStats
+    var currentTankStats: TankStats
+    var tankUpgradeCostAndTime: UpgradeCost
+    var currentTankUpgradeCostAndTime: UpgradeCost
+    var timeAndCostFromCurrentToPotentialStats: UpgradeCost
+
+    static let currentVersion = "0.0.6"
+}

--- a/ios/IronForceUpgradeCalculatorApp/Persistence/UserDefaultsStore.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Persistence/UserDefaultsStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class UserDefaultsStore {
+    private let storeName = "iForce"
+    private let userDefaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var selectedTank: String? {
+        get { value(forKey: "selectedTank") }
+        set { setValue(newValue, forKey: "selectedTank") }
+    }
+
+    func saveCalculatorState(_ state: UpgradeCalculatorState, forTank tank: String) {
+        guard let data = try? encoder.encode(state) else { return }
+        userDefaults.set(data, forKey: namespacedKey("\(tank).upgradeCalculator"))
+    }
+
+    func loadCalculatorState(forTank tank: String) -> UpgradeCalculatorState? {
+        guard let data = userDefaults.data(forKey: namespacedKey("\(tank).upgradeCalculator")) else { return nil }
+        return try? decoder.decode(UpgradeCalculatorState.self, from: data)
+    }
+
+    private func value(forKey key: String) -> String? {
+        userDefaults.string(forKey: namespacedKey(key))
+    }
+
+    private func setValue(_ value: String?, forKey key: String) {
+        userDefaults.set(value, forKey: namespacedKey(key))
+    }
+
+    private func namespacedKey(_ key: String) -> String {
+        "\(storeName).\(key)"
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Resources/tanks.json
+++ b/ios/IronForceUpgradeCalculatorApp/Resources/tanks.json
@@ -1,0 +1,10615 @@
+{
+  "tanks": [
+    {
+      "name": "HYDRUS",
+      "tier": 1,
+      "price": "free",
+      "payType": "",
+      "image": "tank/Hydrus.png",
+      "basicInfo": {
+        "attack": 48,
+        "armor": 250,
+        "fireSpeed": 11.5,
+        "movement": 55
+      }
+    },
+    {
+      "name": "DORADO",
+      "tier": 1,
+      "price": "20,000",
+      "payType": "($)",
+      "image": "tank/Dorado.png",
+      "basicInfo": {
+        "attack": 55,
+        "armor": 350,
+        "fireSpeed": 12.5,
+        "movement": 60
+      }
+    },
+    {
+      "name": "DRACO",
+      "tier": 1,
+      "price": 20,
+      "payType": "(G)",
+      "image": "tank/Draco.png",
+      "basicInfo": {
+        "attack": 68,
+        "armor": 400,
+        "fireSpeed": 11,
+        "movement": 56
+      }
+    },
+    {
+      "name": "URSA",
+      "tier": 2,
+      "price": "100,000",
+      "payType": "($)",
+      "image": "tank/Ursa.png",
+      "basicInfo": {
+        "attack": 80,
+        "armor": 500,
+        "fireSpeed": 10.5,
+        "movement": 55
+      }
+    },
+    {
+      "name": "APUS",
+      "tier": 2,
+      "price": "In-app purchase",
+      "payType": "",
+      "image": "tank/Apus.png",
+      "basicInfo": {
+        "attack": 84,
+        "armor": 550,
+        "fireSpeed": 11.5,
+        "movement": 62
+      }
+    },
+    {
+      "name": "SIRIUS",
+      "tier": 2,
+      "price": 85,
+      "payType": "(G)",
+      "image": "tank/Sirius.png",
+      "basicInfo": {
+        "attack": 100,
+        "armor": 600,
+        "fireSpeed": 8.6,
+        "movement": 55
+      }
+    },
+    {
+      "name": "AQUILA",
+      "tier": 3,
+      "price": "1,000,000",
+      "payType": "($)",
+      "image": "tank/Aquila.png",
+      "basicInfo": {
+        "attack": 110,
+        "armor": 600,
+        "fireSpeed": 9.5,
+        "movement": 60
+      }
+    },
+    {
+      "name": "LUPUS",
+      "tier": 3,
+      "price": 375,
+      "payType": "(G)",
+      "image": "tank/Lupus.png",
+      "basicInfo": {
+        "attack": 135,
+        "armor": 650,
+        "fireSpeed": 9,
+        "movement": 58
+      }
+    },
+    {
+      "name": "CORVUS",
+      "tier": 3,
+      "price": 600,
+      "payType": "(G)",
+      "image": "tank/Corvus.png",
+      "basicInfo": {
+        "attack": 140,
+        "armor": 700,
+        "fireSpeed": 9.5,
+        "movement": 62
+      }
+    },
+    {
+      "name": "LYNX",
+      "tier": 4,
+      "price": "1,000",
+      "payType": "(G)",
+      "image": "tank/Lynx.png",
+      "basicInfo": {
+        "attack": 150,
+        "armor": 800,
+        "fireSpeed": 9.2,
+        "movement": 62
+      }
+    },
+    {
+      "name": "S.LYNX",
+      "tier": 4,
+      "price": "MAX LYNX",
+      "payType": "",
+      "image": "tank/S_Lynx.png",
+      "basicInfo": {
+        "attack": 366,
+        "armor": 2250,
+        "fireSpeed": 9.5,
+        "movement": 65
+      }
+    },
+    {
+      "name": "VULPECULA",
+      "tier": 4,
+      "price": "5,000,000",
+      "payType": "($)",
+      "image": "tank/Vulpecula.png",
+      "basicInfo": {
+        "attack": 130,
+        "armor": 800,
+        "fireSpeed": 9.5,
+        "movement": 60
+      }
+    },
+    {
+      "name": "S.VULPECULA",
+      "tier": 4,
+      "price": "MAX VULPECULA",
+      "payType": "",
+      "image": "tank/S_Vulpecula.png",
+      "basicInfo": {
+        "attack": 345,
+        "armor": 2150,
+        "fireSpeed": 9.6,
+        "movement": 67
+      }
+    },
+    {
+      "name": "LACERTA",
+      "tier": 4,
+      "price": "2,250",
+      "payType": "(G)",
+      "image": "tank/Lacerta.png",
+      "basicInfo": {
+        "attack": 188,
+        "armor": 1050,
+        "fireSpeed": 10,
+        "movement": 64
+      }
+    },
+    {
+      "name": "S.LACERTA",
+      "tier": 4,
+      "price": "MAX LACERTA",
+      "payType": "",
+      "image": "tank/S_Lacerta.png",
+      "basicInfo": {
+        "attack": 425,
+        "armor": 2450,
+        "fireSpeed": 10.5,
+        "movement": 69
+      }
+    },
+    {
+      "name": "SCORPIUS",
+      "tier": 5,
+      "price": "4,500",
+      "payType": "(G)",
+      "image": "tank/Scorpius.png",
+      "basicInfo": {
+        "attack": 170,
+        "armor": 1350,
+        "fireSpeed": 9.5,
+        "movement": 66
+      }
+    },
+    {
+      "name": "S.SCORPIUS",
+      "tier": 5,
+      "price": "MAX SCORPIUS",
+      "payType": "",
+      "image": "tank/S_Scorpius.png",
+      "basicInfo": {
+        "attack": 488,
+        "armor": 2400,
+        "fireSpeed": 9.8,
+        "movement": 72
+      }
+    },
+    {
+      "name": "PAVO",
+      "tier": 5,
+      "price": "4,500",
+      "payType": "(G)",
+      "image": "tank/Pavo.png",
+      "basicInfo": {
+        "attack": 120,
+        "armor": 1250,
+        "fireSpeed": 13.5,
+        "movement": 60
+      }
+    },
+    {
+      "name": "S.PAVO",
+      "tier": 5,
+      "price": "MAX PAVO",
+      "payType": "",
+      "image": "tank/S_Pavo.png",
+      "basicInfo": {
+        "attack": 366,
+        "armor": 2650,
+        "fireSpeed": 12.5,
+        "movement": 70
+      }
+    },
+    {
+      "name": "MONOCEROS",
+      "tier": 5,
+      "price": "5,000",
+      "payType": "(G)",
+      "image": "tank/Monoceros.png",
+      "basicInfo": {
+        "attack": 300,
+        "armor": 1755,
+        "fireSpeed": 9,
+        "movement": 62
+      }
+    },
+    {
+      "name": "S.MONOCEROS",
+      "tier": 5,
+      "price": "MAX MONOSEROS",
+      "payType": "",
+      "image": "tank/S_Monoceros.png",
+      "basicInfo": {
+        "attack": 566,
+        "armor": 3600,
+        "fireSpeed": 9.5,
+        "movement": 67
+      }
+    }
+  ],
+  "tankDetails": {
+    "HYDRUS": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.6,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.9,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 1.2,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1.5,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 0,
+          "fireSpeed": 0,
+          "armor": 0,
+          "movement": 0,
+          "levels": 5,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "totalDiamonds": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 66,
+          "fireSpeed": 13.3,
+          "armor": 379,
+          "movement": 62.2
+        }
+      }
+    },
+    "DORADO": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.6,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 14,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 14,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 21,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 28,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 31,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": -1.6,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 35,
+          "movement": -3.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.7,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.9,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 1.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1.7,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1.6,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 7,
+          "movement": 0.7,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 10,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 11,
+          "movement": 0.7,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 10,
+          "movement": 0.6,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 14,
+          "movement": 1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 73,
+          "fireSpeed": 16.5,
+          "armor": 594,
+          "movement": 69.7,
+          "levels": 7,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 73,
+          "fireSpeed": 16.5,
+          "armor": 524,
+          "movement": 74.5
+        }
+      }
+    },
+    "DRACO": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -1.5,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -3,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -3,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.6,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.9,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 1.2,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1.5,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1.5,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 104,
+          "fireSpeed": 12.2,
+          "armor": 700,
+          "movement": 62,
+          "levels": 9,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 104,
+          "fireSpeed": 12.2,
+          "armor": 571,
+          "movement": 72.4
+        }
+      }
+    },
+    "URSA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -2,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 36,
+          "movement": -3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 36,
+          "movement": -1,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.4,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.4,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.8,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 1.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 1.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 134,
+          "fireSpeed": 12,
+          "armor": 896,
+          "movement": 58.6,
+          "levels": 11,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 128,
+          "fireSpeed": 12.1,
+          "armor": 695,
+          "movement": 69.5
+        }
+      }
+    },
+    "APUS": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 2,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 4,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 4,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -0.5,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -1,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 36,
+          "movement": -1.5,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 36,
+          "movement": -0.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.4,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.4,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.8,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 1.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 1.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 120,
+          "fireSpeed": 13,
+          "armor": 946,
+          "movement": 63.8,
+          "levels": 11,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 116,
+          "fireSpeed": 13.1,
+          "armor": 745,
+          "movement": 69.2
+        }
+      }
+    },
+    "SIRIUS": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 8,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 4,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 4,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 4,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -2,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 36,
+          "movement": -3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 36,
+          "movement": -1,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 42,
+          "movement": -2,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 39,
+          "movement": -2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 45,
+          "movement": -2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.4,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.4,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.8,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 1.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 1.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1.4,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 15,
+          "movement": 0.6,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 15,
+          "movement": 0.8,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 208,
+          "fireSpeed": 10.6,
+          "armor": 1164,
+          "movement": 59,
+          "levels": 14,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 176,
+          "fireSpeed": 11,
+          "armor": 837,
+          "movement": 76
+        }
+      }
+    },
+    "AQUILA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 234750,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 6,
+          "fireSpeed": -0.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 289950,
+          "diamonds": 114
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 3,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 172300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 206750,
+          "diamonds": 114
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 18,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -2,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 36,
+          "movement": -3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 36,
+          "movement": -1,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 42,
+          "movement": -2,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 39,
+          "movement": -2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 45,
+          "movement": -2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 48,
+          "movement": -3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 51,
+          "movement": -1,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.4,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.4,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.8,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 1.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 1.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1.4,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 1.6,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 1.6,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 12,
+          "movement": 0.6,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 15,
+          "movement": 0.6,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 15,
+          "movement": 0.8,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 15,
+          "movement": 0.8,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 18,
+          "movement": 0.8,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 209,
+          "fireSpeed": 11.9,
+          "armor": 1296,
+          "movement": 64.8,
+          "levels": 16,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 170,
+          "fireSpeed": 12.6,
+          "armor": 870,
+          "movement": 85.7
+        }
+      }
+    },
+    "LUPUS": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 3,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 6,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 234750,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 6,
+          "fireSpeed": -0.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 289950,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 310450,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 9,
+          "fireSpeed": -0.2,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 357000,
+          "diamonds": 149
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 6,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 3,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 3,
+          "fireSpeed": 0.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 172300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 206750,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 248100,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 297700,
+          "diamonds": 149
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 12,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 12,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 12,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 24,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 27,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 30,
+          "movement": -1.5,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 30,
+          "movement": -3,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 33,
+          "movement": -3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 36,
+          "movement": -3,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 36,
+          "movement": -4.5,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 36,
+          "movement": -1.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 42,
+          "movement": -3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 39,
+          "movement": -3,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 45,
+          "movement": -3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 48,
+          "movement": -4.5,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 51,
+          "movement": -1.5,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 57,
+          "movement": -3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 268050,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 60,
+          "movement": -3,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 308250,
+          "diamonds": 149
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.6,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.6,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.9,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 1.2,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 1.5,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 1.5,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 1.8,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 1.8,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 1.8,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 2.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 2.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 2.4,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 2.4,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 2.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "movement": 3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 195600,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "movement": 3,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 234700,
+          "diamonds": 149
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 6,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 6,
+          "movement": 0.6,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 9,
+          "movement": 0.4,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 9,
+          "movement": 0.6,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 12,
+          "movement": 0.9,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 15,
+          "movement": 0.9,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 15,
+          "movement": 1.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 15,
+          "movement": 1.2,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 18,
+          "movement": 1.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 18,
+          "movement": 1.2,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 179900,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 21,
+          "movement": 1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 224900,
+          "diamonds": 149
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 252,
+          "fireSpeed": 12,
+          "armor": 1496,
+          "movement": 67.8,
+          "levels": 18,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 195,
+          "fireSpeed": 12.9,
+          "armor": 953,
+          "movement": 105.4
+        }
+      }
+    },
+    "CORVUS": {},
+    "LYNX": {},
+    "S.LYNX": {},
+    "VULPECULA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 9,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 234750,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 9,
+          "fireSpeed": -0.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 289950,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 310450,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 357000,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 410550,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 18,
+          "fireSpeed": -0.2,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 472150,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 519350,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": -0.2,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 571300,
+          "diamonds": 548
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 569380,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 21,
+          "fireSpeed": -0.3,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 569380,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 760450,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 950550,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1188200,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 17,
+          "fireSpeed": -0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1485250,
+          "diamonds": 1218
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 8,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 4,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 4,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 172300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 206750,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 248100,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 297700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 357250,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 428700,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 471550,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 518700,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 570550,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 627600,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 690350,
+          "diamonds": 18184
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": 0.4,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 862950,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078700,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 18,
+          "fireSpeed": 0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1348400,
+          "diamonds": 1218
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 14,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 14,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 21,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 28,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 31,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": -0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 35,
+          "movement": -1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 39,
+          "movement": -1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 42,
+          "movement": -1.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 42,
+          "movement": -2.3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 42,
+          "movement": -0.7,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 49,
+          "movement": -1.5,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 45,
+          "movement": -1.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 53,
+          "movement": -1.5,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 56,
+          "movement": -2.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 59,
+          "movement": -0.7,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 67,
+          "movement": -1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 268050,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 70,
+          "movement": -1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 308250,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 77,
+          "movement": -1.5,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 319050,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 84,
+          "movement": -2.3,
+          "time": "1d 12h",
+          "calcTime": 129600,
+          "price": 407650,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 87,
+          "movement": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 448400,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 95,
+          "movement": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 493250,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 101,
+          "movement": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 542600,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 105,
+          "movement": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 596850,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 109,
+          "movement": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 656550,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 87,
+          "movement": -0.7,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 820700,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 95,
+          "movement": -0.8,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1025900,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 101,
+          "movement": -0.7,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1282400,
+          "diamonds": 1218
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 0.8,
+          "time": "3h 50m",
+          "calcTime": 8400,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 0.8,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 0.7,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 0.9,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 0.9,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 1.2,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 1.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "movement": 1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 195600,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "movement": 1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 234700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "movement": 1.7,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281650,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "movement": 1.6,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 338000,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "movement": 2,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 371800,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "movement": 2.1,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 368100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "movement": 2.1,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 449900,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "movement": 2.2,
+          "time": "2d 2h",
+          "calcTime": 180000,
+          "price": 494900,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "movement": 2.3,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 544400,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "movement": 1.2,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 680500,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "movement": 1.2,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 850650,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "movement": 1.2,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1063300,
+          "diamonds": 1218
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 7,
+          "movement": 0.1,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 7,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 17,
+          "movement": 0.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 18,
+          "movement": 0.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 17,
+          "movement": 0.6,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 179900,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 25,
+          "movement": 0.7,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 224900,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 24,
+          "movement": 0.8,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281150,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 351450,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 421750,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 506100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 35,
+          "movement": 1,
+          "time": "1d 22h",
+          "calcTime": 165600,
+          "price": 607300,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 31,
+          "movement": 1.2,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 728750,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 35,
+          "movement": 1.1,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 874500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 966125,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078950,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 35,
+          "movement": 1,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1191755,
+          "diamonds": 1218
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 625,
+          "fireSpeed": 11.5,
+          "armor": 3043,
+          "movement": 86.1,
+          "levels": 28,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 364,
+          "fireSpeed": 15.4,
+          "armor": 1468,
+          "movement": 110.8
+        }
+      }
+    },
+    "S.VULPECULA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 40,
+          "fireSpeed": 0,
+          "time": "15h 35m",
+          "calcTime": 56100,
+          "price": 108180,
+          "diamonds": 34
+        },
+        {
+          "level": 2,
+          "attack": 20,
+          "fireSpeed": 0,
+          "time": "19h 29m",
+          "calcTime": 70140,
+          "price": 135220,
+          "diamonds": 41
+        },
+        {
+          "level": 3,
+          "attack": 20,
+          "fireSpeed": 0,
+          "time": "21h 39m",
+          "calcTime": 77940,
+          "price": 169020,
+          "diamonds": 46
+        },
+        {
+          "level": 4,
+          "attack": 20,
+          "fireSpeed": 0,
+          "time": "1d",
+          "calcTime": 86400,
+          "price": 194360,
+          "diamonds": 55
+        },
+        {
+          "level": 5,
+          "attack": 20,
+          "fireSpeed": 0,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 223520,
+          "diamonds": 82
+        },
+        {
+          "level": 6,
+          "attack": 20,
+          "fireSpeed": -0.1,
+          "time": "1d 9h",
+          "calcTime": 118800,
+          "price": 279400,
+          "diamonds": 98
+        },
+        {
+          "level": 7,
+          "attack": 40,
+          "fireSpeed": -0.1,
+          "time": "1d 13h",
+          "calcTime": 133200,
+          "price": 295596,
+          "diamonds": 120
+        },
+        {
+          "level": 8,
+          "attack": 40,
+          "fireSpeed": -0.1,
+          "time": "1d 17h 10m",
+          "calcTime": 148200,
+          "price": 339948,
+          "diamonds": 136
+        },
+        {
+          "level": 9,
+          "attack": 20,
+          "fireSpeed": -0.1,
+          "time": "1d 21h 30m",
+          "calcTime": 163800,
+          "price": 373932,
+          "diamonds": 158
+        },
+        {
+          "level": 10,
+          "attack": 40,
+          "fireSpeed": -0.1,
+          "time": "2d 45m",
+          "calcTime": 175500,
+          "price": 411336,
+          "diamonds": 188
+        },
+        {
+          "level": 11,
+          "attack": 40,
+          "fireSpeed": -0.2,
+          "time": "2d 4h",
+          "calcTime": 187200,
+          "price": 452484,
+          "diamonds": 266
+        },
+        {
+          "level": 12,
+          "attack": 40,
+          "fireSpeed": -0.1,
+          "time": "2d 8h 20m",
+          "calcTime": 202800,
+          "price": 497736,
+          "diamonds": 370
+        },
+        {
+          "level": 13,
+          "attack": 40,
+          "fireSpeed": -0.2,
+          "time": "2d 11h 35m",
+          "calcTime": 214500,
+          "price": 547524,
+          "diamonds": 448
+        },
+        {
+          "level": 14,
+          "attack": 40,
+          "fireSpeed": -0.2,
+          "time": "2d 15h 55m",
+          "calcTime": 230100,
+          "price": 684396,
+          "diamonds": 552
+        },
+        {
+          "level": 15,
+          "attack": 60,
+          "fireSpeed": -0.2,
+          "time": "2d 19h 23m",
+          "calcTime": 242580,
+          "price": 855504,
+          "diamonds": 636
+        },
+        {
+          "level": 16,
+          "attack": 40,
+          "fireSpeed": -0.2,
+          "time": "3d 35m",
+          "calcTime": 261300,
+          "price": 1069380,
+          "diamonds": 760
+        },
+        {
+          "level": 17,
+          "attack": 60,
+          "fireSpeed": -0.2,
+          "time": "3d 4h 55m",
+          "calcTime": 276900,
+          "price": 1336716,
+          "diamonds": 864
+        },
+        {
+          "level": 18,
+          "attack": 60,
+          "fireSpeed": -0.2,
+          "time": "3d 11h 25m",
+          "calcTime": 300300,
+          "price": 1670904,
+          "diamonds": 1020
+        },
+        {
+          "level": 19,
+          "attack": 60,
+          "fireSpeed": -0.2,
+          "time": "3d 15h 45m",
+          "calcTime": 315900,
+          "price": 1754460,
+          "diamonds": 1124
+        },
+        {
+          "level": 20,
+          "attack": 80,
+          "fireSpeed": -0.2,
+          "time": "3d 21h 10m",
+          "calcTime": 335400,
+          "price": 1842192,
+          "diamonds": 1254
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 40,
+          "fireSpeed": 0.3,
+          "time": "15h 35m",
+          "calcTime": 56100,
+          "price": 96150,
+          "diamonds": 34
+        },
+        {
+          "level": 2,
+          "attack": 20,
+          "fireSpeed": 0.1,
+          "time": "19h 29m",
+          "calcTime": 70140,
+          "price": 103390,
+          "diamonds": 41
+        },
+        {
+          "level": 3,
+          "attack": 20,
+          "fireSpeed": 0.1,
+          "time": "21h 39m",
+          "calcTime": 77940,
+          "price": 124060,
+          "diamonds": 46
+        },
+        {
+          "level": 4,
+          "attack": 20,
+          "fireSpeed": 0.1,
+          "time": "1d",
+          "calcTime": 86400,
+          "price": 148860,
+          "diamonds": 55
+        },
+        {
+          "level": 5,
+          "attack": 20,
+          "fireSpeed": 0.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 178630,
+          "diamonds": 82
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1d 9h",
+          "calcTime": 118800,
+          "price": 214340,
+          "diamonds": 98
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1d 13h",
+          "calcTime": 133200,
+          "price": 267220,
+          "diamonds": 120
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1d 17h 10m",
+          "calcTime": 148200,
+          "price": 308660,
+          "diamonds": 136
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1d 21h 30m",
+          "calcTime": 163800,
+          "price": 339516,
+          "diamonds": 158
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "2d 45m",
+          "calcTime": 175500,
+          "price": 373464,
+          "diamonds": 188
+        },
+        {
+          "level": 11,
+          "attack": 20,
+          "fireSpeed": 0.3,
+          "time": "2d 4h",
+          "calcTime": 187200,
+          "price": 410796,
+          "diamonds": 266
+        },
+        {
+          "level": 12,
+          "attack": 20,
+          "fireSpeed": 0.2,
+          "time": "2d 8h 20m",
+          "calcTime": 202800,
+          "price": 451872,
+          "diamonds": 370
+        },
+        {
+          "level": 13,
+          "attack": 20,
+          "fireSpeed": 0.3,
+          "time": "2d 11h 35m",
+          "calcTime": 214500,
+          "price": 497052,
+          "diamonds": 448
+        },
+        {
+          "level": 14,
+          "attack": 20,
+          "fireSpeed": 0.3,
+          "time": "2d 15h 55m",
+          "calcTime": 230100,
+          "price": 621324,
+          "diamonds": 552
+        },
+        {
+          "level": 15,
+          "attack": 20,
+          "fireSpeed": 0.4,
+          "time": "2d 19h 23m",
+          "calcTime": 242580,
+          "price": 776664,
+          "diamonds": 636
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "3d 35m",
+          "calcTime": 261300,
+          "price": 970848,
+          "diamonds": 760
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "3d 4h 55m",
+          "calcTime": 276900,
+          "price": 1213560,
+          "diamonds": 864
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "3d 11h 25m",
+          "calcTime": 300300,
+          "price": 1516968,
+          "diamonds": 1020
+        },
+        {
+          "level": 19,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "3d 15h 45m",
+          "calcTime": 315900,
+          "price": 1592820,
+          "diamonds": 1124
+        },
+        {
+          "level": 20,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "3d 21h 10m",
+          "calcTime": 335400,
+          "price": 1672452,
+          "diamonds": 1254
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 46,
+          "movement": 0,
+          "time": "15h 35m",
+          "calcTime": 56100,
+          "price": 93380,
+          "diamonds": 34
+        },
+        {
+          "level": 2,
+          "armor": 46,
+          "movement": 0,
+          "time": "19h 29m",
+          "calcTime": 70140,
+          "price": 116750,
+          "diamonds": 41
+        },
+        {
+          "level": 3,
+          "armor": 68,
+          "movement": 0,
+          "time": "21h 39m",
+          "calcTime": 77940,
+          "price": 145940,
+          "diamonds": 46
+        },
+        {
+          "level": 4,
+          "armor": 91,
+          "movement": 0,
+          "time": "1d",
+          "calcTime": 86400,
+          "price": 167830,
+          "diamonds": 55
+        },
+        {
+          "level": 5,
+          "armor": 103,
+          "movement": 0,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 193000,
+          "diamonds": 82
+        },
+        {
+          "level": 6,
+          "armor": 114,
+          "movement": -0.6,
+          "time": "1d 9h",
+          "calcTime": 118800,
+          "price": 221940,
+          "diamonds": 98
+        },
+        {
+          "level": 7,
+          "armor": 114,
+          "movement": -0.7,
+          "time": "1d 13h",
+          "calcTime": 133200,
+          "price": 255240,
+          "diamonds": 120
+        },
+        {
+          "level": 8,
+          "armor": 125,
+          "movement": -0.7,
+          "time": "1d 17h 10m",
+          "calcTime": 148200,
+          "price": 293508,
+          "diamonds": 136
+        },
+        {
+          "level": 9,
+          "armor": 137,
+          "movement": -0.7,
+          "time": "1d 21h 30m",
+          "calcTime": 163800,
+          "price": 322848,
+          "diamonds": 158
+        },
+        {
+          "level": 10,
+          "armor": 137,
+          "movement": -0.7,
+          "time": "2d 45m",
+          "calcTime": 175500,
+          "price": 355140,
+          "diamonds": 188
+        },
+        {
+          "level": 11,
+          "armor": 137,
+          "movement": -1.4,
+          "time": "2d 4h",
+          "calcTime": 187200,
+          "price": 390672,
+          "diamonds": 266
+        },
+        {
+          "level": 12,
+          "armor": 160,
+          "movement": -1.4,
+          "time": "2d 8h 20m",
+          "calcTime": 202800,
+          "price": 429732,
+          "diamonds": 370
+        },
+        {
+          "level": 13,
+          "armor": 148,
+          "movement": -1.4,
+          "time": "2d 11h 35m",
+          "calcTime": 214500,
+          "price": 472716,
+          "diamonds": 448
+        },
+        {
+          "level": 14,
+          "armor": 171,
+          "movement": -1.4,
+          "time": "2d 15h 55m",
+          "calcTime": 230100,
+          "price": 590904,
+          "diamonds": 552
+        },
+        {
+          "level": 15,
+          "armor": 182,
+          "movement": -1.4,
+          "time": "2d 19h 23m",
+          "calcTime": 242580,
+          "price": 738648,
+          "diamonds": 636
+        },
+        {
+          "level": 16,
+          "armor": 194,
+          "movement": -1.4,
+          "time": "3d 35m",
+          "calcTime": 261300,
+          "price": 923328,
+          "diamonds": 760
+        },
+        {
+          "level": 17,
+          "armor": 217,
+          "movement": -1.4,
+          "time": "3d 4h 55m",
+          "calcTime": 276900,
+          "price": 1154160,
+          "diamonds": 864
+        },
+        {
+          "level": 18,
+          "armor": 228,
+          "movement": -1.4,
+          "time": "3d 11h 25m",
+          "calcTime": 300300,
+          "price": 1442700,
+          "diamonds": 1020
+        },
+        {
+          "level": 19,
+          "armor": 251,
+          "movement": -1.4,
+          "time": "3d 15h 45m",
+          "calcTime": 315900,
+          "price": 1514844,
+          "diamonds": 1124
+        },
+        {
+          "level": 20,
+          "armor": 274,
+          "movement": -1.4,
+          "time": "3d 21h 10m",
+          "calcTime": 335400,
+          "price": 1590588,
+          "diamonds": 1254
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.5,
+          "time": "15h 35m",
+          "calcTime": 56100,
+          "price": 65200,
+          "diamonds": 34
+        },
+        {
+          "level": 2,
+          "movement": 0.5,
+          "time": "19h 29m",
+          "calcTime": 70140,
+          "price": 81500,
+          "diamonds": 41
+        },
+        {
+          "level": 3,
+          "movement": 0.7,
+          "time": "21h 39m",
+          "calcTime": 77940,
+          "price": 97810,
+          "diamonds": 46
+        },
+        {
+          "level": 4,
+          "movement": 0.8,
+          "time": "1d",
+          "calcTime": 86400,
+          "price": 117360,
+          "diamonds": 55
+        },
+        {
+          "level": 5,
+          "movement": 0.8,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 140830,
+          "diamonds": 82
+        },
+        {
+          "level": 6,
+          "movement": 1,
+          "time": "1d 9h",
+          "calcTime": 118800,
+          "price": 168980,
+          "diamonds": 98
+        },
+        {
+          "level": 7,
+          "movement": 0.8,
+          "time": "1d 13h 55m",
+          "calcTime": 136500,
+          "price": 202788,
+          "diamonds": 120
+        },
+        {
+          "level": 8,
+          "movement": 1.1,
+          "time": "1d 17h 10m",
+          "calcTime": 148200,
+          "price": 243360,
+          "diamonds": 136
+        },
+        {
+          "level": 9,
+          "movement": 0.9,
+          "time": "1d 21h 30m",
+          "calcTime": 163800,
+          "price": 267696,
+          "diamonds": 158
+        },
+        {
+          "level": 10,
+          "movement": 1.1,
+          "time": "2d 45m",
+          "calcTime": 175500,
+          "price": 294480,
+          "diamonds": 188
+        },
+        {
+          "level": 11,
+          "movement": 1.2,
+          "time": "2d 4h",
+          "calcTime": 187200,
+          "price": 323928,
+          "diamonds": 266
+        },
+        {
+          "level": 12,
+          "movement": 1.4,
+          "time": "2d 8h 20m",
+          "calcTime": 202800,
+          "price": 356328,
+          "diamonds": 370
+        },
+        {
+          "level": 13,
+          "movement": 1.4,
+          "time": "2d 11h 35m",
+          "calcTime": 214500,
+          "price": 391968,
+          "diamonds": 448
+        },
+        {
+          "level": 14,
+          "movement": 1.4,
+          "time": "2d 15h 55m",
+          "calcTime": 230100,
+          "price": 489960,
+          "diamonds": 552
+        },
+        {
+          "level": 15,
+          "movement": 1.4,
+          "time": "2d 19h 23m",
+          "calcTime": 242580,
+          "price": 612468,
+          "diamonds": 636
+        },
+        {
+          "level": 16,
+          "movement": 1.4,
+          "time": "3d 35m",
+          "calcTime": 261300,
+          "price": 765576,
+          "diamonds": 760
+        },
+        {
+          "level": 17,
+          "movement": 1.4,
+          "time": "3d 4h 55m",
+          "calcTime": 276900,
+          "price": 956988,
+          "diamonds": 864
+        },
+        {
+          "level": 18,
+          "movement": 1.4,
+          "time": "3d 11h 25m",
+          "calcTime": 300300,
+          "price": 1196244,
+          "diamonds": 1020
+        },
+        {
+          "level": 19,
+          "movement": 1.4,
+          "time": "3d 15h 45m",
+          "calcTime": 315900,
+          "price": 1256040,
+          "diamonds": 1124
+        },
+        {
+          "level": 20,
+          "movement": 1.4,
+          "time": "3d 21h 10m",
+          "calcTime": 335400,
+          "price": 1318860,
+          "diamonds": 1254
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 23,
+          "movement": 0.4,
+          "time": "15h 35m",
+          "calcTime": 56100,
+          "price": 49030,
+          "diamonds": 34
+        },
+        {
+          "level": 2,
+          "armor": 23,
+          "movement": 0.4,
+          "time": "19h 29m",
+          "calcTime": 70140,
+          "price": 63760,
+          "diamonds": 41
+        },
+        {
+          "level": 3,
+          "armor": 23,
+          "movement": 0.4,
+          "time": "21h 39m",
+          "calcTime": 77940,
+          "price": 82870,
+          "diamonds": 46
+        },
+        {
+          "level": 4,
+          "armor": 34,
+          "movement": 0.4,
+          "time": "1d",
+          "calcTime": 86400,
+          "price": 103610,
+          "diamonds": 55
+        },
+        {
+          "level": 5,
+          "armor": 34,
+          "movement": 0.4,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 129530,
+          "diamonds": 82
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": 0.7,
+          "time": "1d 9h",
+          "calcTime": 118800,
+          "price": 161930,
+          "diamonds": 98
+        },
+        {
+          "level": 7,
+          "armor": 45,
+          "movement": 0.4,
+          "time": "1d 13h 55m",
+          "calcTime": 136500,
+          "price": 202430,
+          "diamonds": 120
+        },
+        {
+          "level": 8,
+          "armor": 34,
+          "movement": 0.5,
+          "time": "1d 17h 10m",
+          "calcTime": 148200,
+          "price": 253044,
+          "diamonds": 136
+        },
+        {
+          "level": 9,
+          "armor": 46,
+          "movement": 0.7,
+          "time": "1d 21h 30m",
+          "calcTime": 163800,
+          "price": 303660,
+          "diamonds": 158
+        },
+        {
+          "level": 10,
+          "armor": 46,
+          "movement": 0.5,
+          "time": "2d 45m",
+          "calcTime": 175500,
+          "price": 364392,
+          "diamonds": 188
+        },
+        {
+          "level": 11,
+          "armor": 46,
+          "movement": 0.7,
+          "time": "2d 4h",
+          "calcTime": 187200,
+          "price": 437256,
+          "diamonds": 266
+        },
+        {
+          "level": 12,
+          "armor": 46,
+          "movement": 0.5,
+          "time": "2d 8h 20m",
+          "calcTime": 202800,
+          "price": 524700,
+          "diamonds": 370
+        },
+        {
+          "level": 13,
+          "armor": 57,
+          "movement": 0.8,
+          "time": "2d 11h 35m",
+          "calcTime": 214500,
+          "price": 629640,
+          "diamonds": 448
+        },
+        {
+          "level": 14,
+          "armor": 57,
+          "movement": 0.8,
+          "time": "2d 15h 55m",
+          "calcTime": 230100,
+          "price": 695610,
+          "diamonds": 552
+        },
+        {
+          "level": 15,
+          "armor": 57,
+          "movement": 0.8,
+          "time": "2d 19h 23m",
+          "calcTime": 242580,
+          "price": 776837,
+          "diamonds": 636
+        },
+        {
+          "level": 16,
+          "armor": 68,
+          "movement": 0.8,
+          "time": "3d 35m",
+          "calcTime": 261300,
+          "price": 858064,
+          "diamonds": 760
+        },
+        {
+          "level": 17,
+          "armor": 68,
+          "movement": 1.1,
+          "time": "3d 4h 55m",
+          "calcTime": 276900,
+          "price": 939290,
+          "diamonds": 864
+        },
+        {
+          "level": 18,
+          "armor": 80,
+          "movement": 0.9,
+          "time": "3d 11h 25m",
+          "calcTime": 300300,
+          "price": 1020517,
+          "diamonds": 1020
+        },
+        {
+          "level": 19,
+          "armor": 80,
+          "movement": 1.2,
+          "time": "3d 15h 45m",
+          "calcTime": 315900,
+          "price": 1101744,
+          "diamonds": 1124
+        },
+        {
+          "level": 20,
+          "armor": 91,
+          "movement": 1.2,
+          "time": "3d 21h 10m",
+          "calcTime": 335400,
+          "price": 1182971,
+          "diamonds": 1254
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 1365,
+          "fireSpeed": 12.4,
+          "armor": 6086,
+          "movement": 85,
+          "levels": 20,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 685,
+          "fireSpeed": 14.7,
+          "armor": 3497,
+          "movement": 102.4
+        }
+      }
+    },
+    "LACERTA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 9,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 234750,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 9,
+          "fireSpeed": -0.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 289950,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 310450,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 357000,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 410550,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 18,
+          "fireSpeed": -0.2,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 472150,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 519350,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": -0.2,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 571300,
+          "diamonds": 548
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 569380,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 21,
+          "fireSpeed": -0.3,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 569380,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 760450,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 950550,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1188200,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 17,
+          "fireSpeed": -0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1485250,
+          "diamonds": 1218
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 8,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 4,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 4,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 172300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 206750,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 248100,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 297700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 357250,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 428700,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 471550,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 518700,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 570550,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 627600,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 690350,
+          "diamonds": 18184
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": 0.4,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 862950,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078700,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 18,
+          "fireSpeed": 0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1348400,
+          "diamonds": 1218
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 14,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 14,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 21,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 28,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 31,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": -0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 35,
+          "movement": -1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 39,
+          "movement": -1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 42,
+          "movement": -1.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 42,
+          "movement": -2.3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 42,
+          "movement": -0.7,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 49,
+          "movement": -1.5,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 45,
+          "movement": -1.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 53,
+          "movement": -1.5,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 56,
+          "movement": -2.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 59,
+          "movement": -0.7,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 67,
+          "movement": -1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 268050,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 70,
+          "movement": -1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 308250,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 77,
+          "movement": -1.5,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 319050,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 84,
+          "movement": -2.3,
+          "time": "1d 12h",
+          "calcTime": 129600,
+          "price": 407650,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 87,
+          "movement": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 448400,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 95,
+          "movement": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 493250,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 101,
+          "movement": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 542600,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 105,
+          "movement": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 596850,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 109,
+          "movement": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 656550,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 87,
+          "movement": -0.7,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 820700,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 95,
+          "movement": -0.8,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1025900,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 101,
+          "movement": -0.7,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1282400,
+          "diamonds": 1218
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 0.8,
+          "time": "3h 50m",
+          "calcTime": 8400,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 0.8,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 0.7,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 0.9,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 0.9,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 1.2,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 1.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "movement": 1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 195600,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "movement": 1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 234700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "movement": 1.7,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281650,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "movement": 1.6,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 338000,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "movement": 2,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 371800,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "movement": 2.1,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 368100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "movement": 2.1,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 449900,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "movement": 2.2,
+          "time": "2d 2h",
+          "calcTime": 180000,
+          "price": 494900,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "movement": 2.3,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 544400,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "movement": 1.2,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 680500,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "movement": 1.2,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 850650,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "movement": 1.2,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1063300,
+          "diamonds": 1218
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 7,
+          "movement": 0.1,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 7,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 17,
+          "movement": 0.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 18,
+          "movement": 0.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 17,
+          "movement": 0.6,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 179900,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 25,
+          "movement": 0.7,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 224900,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 24,
+          "movement": 0.8,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281150,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 351450,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 421750,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 506100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 35,
+          "movement": 1,
+          "time": "1d 22h",
+          "calcTime": 165600,
+          "price": 607300,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 31,
+          "movement": 1.2,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 728750,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 35,
+          "movement": 1.1,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 874500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 966125,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078950,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 35,
+          "movement": 1,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1191755,
+          "diamonds": 1218
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 625,
+          "fireSpeed": 11.5,
+          "armor": 3043,
+          "movement": 86.1,
+          "levels": 28,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 364,
+          "fireSpeed": 15.4,
+          "armor": 1468,
+          "movement": 110.8
+        }
+      }
+    },
+    "S.LACERTA": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 4050,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 6550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 10600,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 17150,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 4,
+          "fireSpeed": 0,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 23150,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 9,
+          "fireSpeed": 0,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 31250,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 42200,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 56950,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 76900,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "20h 50",
+          "calcTime": 75000,
+          "price": 96150,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 120200,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 9,
+          "fireSpeed": -0.1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 150250,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 8,
+          "fireSpeed": -0.1,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 187800,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 234750,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 9,
+          "fireSpeed": -0.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 289950,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 13,
+          "fireSpeed": -0.1,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 310450,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 357000,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 13,
+          "fireSpeed": -0.2,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 410550,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 18,
+          "fireSpeed": -0.2,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 472150,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 519350,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": -0.2,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 571300,
+          "diamonds": 548
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 569380,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 21,
+          "fireSpeed": -0.3,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 569380,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 18,
+          "fireSpeed": -0.4,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 760450,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": -0.3,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 950550,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1188200,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 17,
+          "fireSpeed": -0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1485250,
+          "diamonds": 1218
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2250,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3650,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5900,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9550,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 15450,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20850,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 28150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 38000,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 51300,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 69250,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "attack": 8,
+          "fireSpeed": 0.2,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83100,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 99700,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "attack": 4,
+          "fireSpeed": 0.2,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 119650,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "attack": 4,
+          "fireSpeed": 0.3,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 143600,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 172300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 206750,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 248100,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 297700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 357250,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 428700,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 471550,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 518700,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "attack": 18,
+          "fireSpeed": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 570550,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 627600,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 17,
+          "fireSpeed": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 690350,
+          "diamonds": 18184
+        },
+        {
+          "level": 26,
+          "attack": 17,
+          "fireSpeed": 0.4,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 862950,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078700,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 18,
+          "fireSpeed": 0.4,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1348400,
+          "diamonds": 1218
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 14,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 14,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 21,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 28,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 31,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": -0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 35,
+          "movement": -1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 39,
+          "movement": -1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 42,
+          "movement": -1.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 42,
+          "movement": -2.3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 42,
+          "movement": -0.7,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 49,
+          "movement": -1.5,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 45,
+          "movement": -1.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 53,
+          "movement": -1.5,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 56,
+          "movement": -2.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 59,
+          "movement": -0.7,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 67,
+          "movement": -1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 268050,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 70,
+          "movement": -1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 308250,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 77,
+          "movement": -1.5,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 319050,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 84,
+          "movement": -2.3,
+          "time": "1d 12h",
+          "calcTime": 129600,
+          "price": 407650,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 87,
+          "movement": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 448400,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 95,
+          "movement": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 493250,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 101,
+          "movement": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 542600,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 105,
+          "movement": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 596850,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 109,
+          "movement": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 656550,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 87,
+          "movement": -0.7,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 820700,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 95,
+          "movement": -0.8,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1025900,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 101,
+          "movement": -0.7,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1282400,
+          "diamonds": 1218
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 0.8,
+          "time": "3h 50m",
+          "calcTime": 8400,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 0.8,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 0.7,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 0.9,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 0.9,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 1.2,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 1.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "movement": 1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 195600,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "movement": 1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 234700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "movement": 1.7,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281650,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "movement": 1.6,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 338000,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "movement": 2,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 371800,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "movement": 2.1,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 368100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "movement": 2.1,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 449900,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "movement": 2.2,
+          "time": "2d 2h",
+          "calcTime": 180000,
+          "price": 494900,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "movement": 2.3,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 544400,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "movement": 1.2,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 680500,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "movement": 1.2,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 850650,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "movement": 1.2,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1063300,
+          "diamonds": 1218
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 7,
+          "movement": 0.1,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 7,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 17,
+          "movement": 0.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 18,
+          "movement": 0.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 17,
+          "movement": 0.6,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 179900,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 25,
+          "movement": 0.7,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 224900,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 24,
+          "movement": 0.8,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281150,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 351450,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 421750,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 506100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 35,
+          "movement": 1,
+          "time": "1d 22h",
+          "calcTime": 165600,
+          "price": 607300,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 31,
+          "movement": 1.2,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 728750,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 35,
+          "movement": 1.1,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 874500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 966125,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078950,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 35,
+          "movement": 1,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1191755,
+          "diamonds": 1218
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 625,
+          "fireSpeed": 11.5,
+          "armor": 3043,
+          "movement": 86.1,
+          "levels": 28,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 364,
+          "fireSpeed": 15.4,
+          "armor": 1468,
+          "movement": 110.8
+        }
+      }
+    },
+    "SCORPIUS": {
+      "turret": [
+        {
+          "level": 1,
+          "attack": 11,
+          "fireSpeed": 0,
+          "time": "20h 23m",
+          "calcTime": 73380,
+          "price": 195330,
+          "diamonds": 43
+        },
+        {
+          "level": 2,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "1d 1h 30m",
+          "calcTime": 91800,
+          "price": 244140,
+          "diamonds": 58
+        },
+        {
+          "level": 3,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1d 4h 20m",
+          "calcTime": 102000,
+          "price": 305940,
+          "diamonds": 72
+        },
+        {
+          "level": 4,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "1d 8h 30m",
+          "calcTime": 117000,
+          "price": 350940,
+          "diamonds": 93
+        },
+        {
+          "level": 5,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "1d 15h 40m",
+          "calcTime": 142800,
+          "price": 403590,
+          "diamonds": 129
+        },
+        {
+          "level": 6,
+          "attack": 5,
+          "fireSpeed": 0,
+          "time": "1d 20h",
+          "calcTime": 158400,
+          "price": 464100,
+          "diamonds": 150
+        },
+        {
+          "level": 7,
+          "attack": 11,
+          "fireSpeed": 0,
+          "time": "2d 1h 50m",
+          "calcTime": 179400,
+          "price": 533720,
+          "diamonds": 210
+        },
+        {
+          "level": 8,
+          "attack": 11,
+          "fireSpeed": 0,
+          "time": "2d 6h",
+          "calcTime": 194400,
+          "price": 613800,
+          "diamonds": 330
+        },
+        {
+          "level": 9,
+          "attack": 6,
+          "fireSpeed": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 675160,
+          "diamonds": 484
+        },
+        {
+          "level": 10,
+          "attack": 8,
+          "fireSpeed": 0,
+          "time": "2d 15h 30m",
+          "calcTime": 228600,
+          "price": 742690,
+          "diamonds": 600
+        },
+        {
+          "level": 11,
+          "attack": 11,
+          "fireSpeed": -0.1,
+          "time": "2d 19h 30",
+          "calcTime": 243000,
+          "price": 816990,
+          "diamonds": 716
+        },
+        {
+          "level": 12,
+          "attack": 11,
+          "fireSpeed": -0.1,
+          "time": "3d 2h",
+          "calcTime": 266400,
+          "price": 898690,
+          "diamonds": 870
+        },
+        {
+          "level": 13,
+          "attack": 1,
+          "fireSpeed": -0.1,
+          "time": "3d 5h 30m",
+          "calcTime": 279000,
+          "price": 988590,
+          "diamonds": 986
+        },
+        {
+          "level": 14,
+          "attack": 11,
+          "fireSpeed": -0.1,
+          "time": "3d 11h 20m",
+          "calcTime": 300000,
+          "price": 1235720,
+          "diamonds": 1141
+        },
+        {
+          "level": 15,
+          "attack": 16,
+          "fireSpeed": -0.1,
+          "time": "3d 16h 30m",
+          "calcTime": 318600,
+          "price": 1544660,
+          "diamonds": 1265
+        },
+        {
+          "level": 16,
+          "attack": 1,
+          "fireSpeed": -0.2,
+          "time": "3d 22h 30m",
+          "calcTime": 340200,
+          "price": 1930830,
+          "diamonds": 1450
+        },
+        {
+          "level": 17,
+          "attack": 17,
+          "fireSpeed": -0.1,
+          "time": "4d 4h 30m",
+          "calcTime": 361800,
+          "price": 2413520,
+          "diamonds": 1618
+        },
+        {
+          "level": 18,
+          "attack": 16,
+          "fireSpeed": -0.2,
+          "time": "4d 13h",
+          "calcTime": 392400,
+          "price": 3016910,
+          "diamonds": 1873
+        },
+        {
+          "level": 19,
+          "attack": 17,
+          "fireSpeed": -0.2,
+          "time": "4d 18h 30m",
+          "calcTime": 412200,
+          "price": 3167780,
+          "diamonds": 2043
+        },
+        {
+          "level": 20,
+          "attack": 22,
+          "fireSpeed": -0.2,
+          "time": "5d 1h 20m",
+          "calcTime": 436800,
+          "price": 3326180,
+          "diamonds": 2255
+        },
+        {
+          "level": 21,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "5d 7h 30m",
+          "calcTime": 459000,
+          "price": 3468750,
+          "diamonds": 2425
+        },
+        {
+          "level": 22,
+          "attack": 22,
+          "fireSpeed": -0.2,
+          "time": "5d 11h 30m",
+          "calcTime": 473400,
+          "price": 3614160,
+          "diamonds": 2553
+        },
+        {
+          "level": 23,
+          "attack": 22,
+          "fireSpeed": -0.4,
+          "time": "5d 17h 30m",
+          "calcTime": 495000,
+          "price": 3762480,
+          "diamonds": 2723
+        },
+        {
+          "level": 24,
+          "attack": 27,
+          "fireSpeed": -0.3,
+          "time": "5d 23h",
+          "calcTime": 514800,
+          "price": 3912980,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 22,
+          "fireSpeed": -0.4,
+          "time": "6d 5h 10m",
+          "calcTime": 537000,
+          "price": 4069500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "6d 11h",
+          "calcTime": 558000,
+          "price": 4232280,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 28,
+          "fireSpeed": -0.3,
+          "time": "6d 17h 20m",
+          "calcTime": 580800,
+          "price": 4401550,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 22,
+          "fireSpeed": -0.4,
+          "time": "6d 23h 30m",
+          "calcTime": 603000,
+          "price": 4577650,
+          "diamonds": 1218
+        },
+        {
+          "level": 29,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "7d 6h 10m",
+          "calcTime": 627000,
+          "price": 4760750,
+          "diamonds": 1218
+        },
+        {
+          "level": 30,
+          "attack": 22,
+          "fireSpeed": -0.3,
+          "time": "7d 12h 50m",
+          "calcTime": 651000,
+          "price": 4951180,
+          "diamonds": 1218
+        },
+        {
+          "level": 31,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "7d 19h 30m",
+          "calcTime": 675000,
+          "price": 5149250,
+          "diamonds": 1218
+        },
+        {
+          "level": 32,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "8d 3h",
+          "calcTime": 702000,
+          "price": 5355220,
+          "diamonds": 1218
+        },
+        {
+          "level": 33,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "8d 10h 30m",
+          "calcTime": 729000,
+          "price": 5569450,
+          "diamonds": 1218
+        },
+        {
+          "level": 34,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "8d 18h 50m",
+          "calcTime": 759000,
+          "price": 5792250,
+          "diamonds": 1218
+        },
+        {
+          "level": 35,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "9d 3h 10m",
+          "calcTime": 789000,
+          "price": 6023940,
+          "diamonds": 1218
+        }
+      ],
+      "barrel": [
+        {
+          "level": 1,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "20h 23m",
+          "calcTime": 73380,
+          "price": 155550,
+          "diamonds": 43
+        },
+        {
+          "level": 2,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1d 1h 30m",
+          "calcTime": 91800,
+          "price": 186680,
+          "diamonds": 58
+        },
+        {
+          "level": 3,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1d 4h 20m",
+          "calcTime": 102000,
+          "price": 223990,
+          "diamonds": 72
+        },
+        {
+          "level": 4,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1d 8h 30m",
+          "calcTime": 117000,
+          "price": 268780,
+          "diamonds": 93
+        },
+        {
+          "level": 5,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "1d 15h 40m",
+          "calcTime": 142800,
+          "price": 322530,
+          "diamonds": 129
+        },
+        {
+          "level": 6,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "1d 20h",
+          "calcTime": 158400,
+          "price": 387010,
+          "diamonds": 150
+        },
+        {
+          "level": 7,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "2d 1h 50m",
+          "calcTime": 179400,
+          "price": 464430,
+          "diamonds": 210
+        },
+        {
+          "level": 8,
+          "attack": 0,
+          "fireSpeed": 0.1,
+          "time": "2d 6h",
+          "calcTime": 194400,
+          "price": 557310,
+          "diamonds": 330
+        },
+        {
+          "level": 9,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 613020,
+          "diamonds": 484
+        },
+        {
+          "level": 10,
+          "attack": 0,
+          "fireSpeed": 0.2,
+          "time": "2d 15h 30m",
+          "calcTime": 228600,
+          "price": 674310,
+          "diamonds": 600
+        },
+        {
+          "level": 11,
+          "attack": 11,
+          "fireSpeed": 0.2,
+          "time": "2d 19h 30",
+          "calcTime": 243000,
+          "price": 741720,
+          "diamonds": 716
+        },
+        {
+          "level": 12,
+          "attack": 5,
+          "fireSpeed": 0.3,
+          "time": "3d 2h",
+          "calcTime": 266400,
+          "price": 815880,
+          "diamonds": 870
+        },
+        {
+          "level": 13,
+          "attack": 6,
+          "fireSpeed": 0.2,
+          "time": "3d 5h 30m",
+          "calcTime": 279000,
+          "price": 897460,
+          "diamonds": 986
+        },
+        {
+          "level": 14,
+          "attack": 6,
+          "fireSpeed": 0.3,
+          "time": "3d 11h 20m",
+          "calcTime": 300000,
+          "price": 1121840,
+          "diamonds": 1141
+        },
+        {
+          "level": 15,
+          "attack": 6,
+          "fireSpeed": 0.3,
+          "time": "3d 16h 30m",
+          "calcTime": 318600,
+          "price": 1402310,
+          "diamonds": 1265
+        },
+        {
+          "level": 16,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "3d 22h 30m",
+          "calcTime": 340200,
+          "price": 1752920,
+          "diamonds": 1450
+        },
+        {
+          "level": 17,
+          "attack": 0,
+          "fireSpeed": 0.3,
+          "time": "4d 4h 30m",
+          "calcTime": 361800,
+          "price": 2191150,
+          "diamonds": 1618
+        },
+        {
+          "level": 18,
+          "attack": 0,
+          "fireSpeed": 0.5,
+          "time": "4d 13h",
+          "calcTime": 392400,
+          "price": 2738970,
+          "diamonds": 1873
+        },
+        {
+          "level": 19,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "4d 18h 30m",
+          "calcTime": 412200,
+          "price": 2875930,
+          "diamonds": 2043
+        },
+        {
+          "level": 20,
+          "attack": 0,
+          "fireSpeed": 0.4,
+          "time": "5d 1h 20m",
+          "calcTime": 436800,
+          "price": 3019710,
+          "diamonds": 2255
+        },
+        {
+          "level": 21,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "5d 7h 30m",
+          "calcTime": 459000,
+          "price": 3149110,
+          "diamonds": 2425
+        },
+        {
+          "level": 22,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "5d 11h 30m",
+          "calcTime": 473400,
+          "price": 3281100,
+          "diamonds": 2553
+        },
+        {
+          "level": 23,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "5d 17h 30m",
+          "calcTime": 495000,
+          "price": 3415730,
+          "diamonds": 2723
+        },
+        {
+          "level": 24,
+          "attack": 27,
+          "fireSpeed": 0,
+          "time": "5d 23h",
+          "calcTime": 514800,
+          "price": 3912980,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "attack": 22,
+          "fireSpeed": 0,
+          "time": "6d 5h 10m",
+          "calcTime": 537000,
+          "price": 4069500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "6d 11h",
+          "calcTime": 558000,
+          "price": 4232280,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "attack": 28,
+          "fireSpeed": 0.4,
+          "time": "6d 17h 20m",
+          "calcTime": 580800,
+          "price": 4401550,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "6d 23h 30m",
+          "calcTime": 603000,
+          "price": 4577650,
+          "diamonds": 1218
+        },
+        {
+          "level": 29,
+          "attack": 22,
+          "fireSpeed": 0.4,
+          "time": "7d 6h 10m",
+          "calcTime": 627000,
+          "price": 4760750,
+          "diamonds": 1218
+        },
+        {
+          "level": 30,
+          "attack": 22,
+          "fireSpeed": 0.5,
+          "time": "7d 12h 50m",
+          "calcTime": 651000,
+          "price": 4951180,
+          "diamonds": 1218
+        },
+        {
+          "level": 31,
+          "attack": 22,
+          "fireSpeed": 0.2,
+          "time": "7d 19h 30m",
+          "calcTime": 675000,
+          "price": 5149250,
+          "diamonds": 1218
+        },
+        {
+          "level": 32,
+          "attack": 22,
+          "fireSpeed": 0.2,
+          "time": "8d 3h",
+          "calcTime": 702000,
+          "price": 5355220,
+          "diamonds": 1218
+        },
+        {
+          "level": 33,
+          "attack": 22,
+          "fireSpeed": 0.2,
+          "time": "8d 10h 30m",
+          "calcTime": 729000,
+          "price": 5569450,
+          "diamonds": 1218
+        },
+        {
+          "level": 34,
+          "attack": 22,
+          "fireSpeed": 0.2,
+          "time": "8d 18h 50m",
+          "calcTime": 759000,
+          "price": 5792250,
+          "diamonds": 1218
+        },
+        {
+          "level": 35,
+          "attack": 22,
+          "fireSpeed": 0.2,
+          "time": "9d 3h 10m",
+          "calcTime": 789000,
+          "price": 6023940,
+          "diamonds": 1218
+        }
+      ],
+      "armor": [
+        {
+          "level": 1,
+          "armor": 14,
+          "movement": 0,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 2150,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 14,
+          "movement": 0,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 3500,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 21,
+          "movement": 0,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 5650,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 28,
+          "movement": 0,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 9150,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 31,
+          "movement": 0,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 14800,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 35,
+          "movement": -0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 20000,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 35,
+          "movement": -1.5,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 27000,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 39,
+          "movement": -1.5,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 36450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 42,
+          "movement": -1.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 49200,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 42,
+          "movement": -2.3,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 66400,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 42,
+          "movement": -0.7,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 83000,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 49,
+          "movement": -1.5,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 103750,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 45,
+          "movement": -1.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 129700,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 53,
+          "movement": -1.5,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 162150,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 56,
+          "movement": -2.3,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 202300,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 59,
+          "movement": -0.7,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 233100,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 67,
+          "movement": -1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 268050,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 70,
+          "movement": -1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 308250,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 77,
+          "movement": -1.5,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 319050,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 84,
+          "movement": -2.3,
+          "time": "1d 12h",
+          "calcTime": 129600,
+          "price": 407650,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 87,
+          "movement": 0,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 448400,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 95,
+          "movement": 0,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 493250,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 101,
+          "movement": 0,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 542600,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 105,
+          "movement": 0,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 596850,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 109,
+          "movement": 0,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 656550,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 87,
+          "movement": -0.7,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 820700,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 95,
+          "movement": -0.8,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1025900,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 101,
+          "movement": -0.7,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1282400,
+          "diamonds": 1218
+        }
+      ],
+      "engine": [
+        {
+          "level": 1,
+          "movement": 0.3,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 1500,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "movement": 0.3,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 2450,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "movement": 0.4,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 3950,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "movement": 0.6,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 6400,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "movement": 0.8,
+          "time": "3h 50m",
+          "calcTime": 8400,
+          "price": 10350,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "movement": 0.7,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 13950,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "movement": 0.8,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 18850,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "movement": 0.7,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 25450,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "movement": 0.9,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 34350,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "movement": 0.9,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 46350,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "movement": 0.9,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 57950,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "movement": 1.1,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 72450,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "movement": 1,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 90550,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "movement": 1.2,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 113200,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "movement": 1.2,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 135850,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "movement": 1.2,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 163000,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "movement": 1.5,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 195600,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "movement": 1.5,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 234700,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "movement": 1.7,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281650,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "movement": 1.6,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 338000,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "movement": 2,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 371800,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "movement": 2.1,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 368100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "movement": 2.1,
+          "time": "2d 15h 20m",
+          "calcTime": 228000,
+          "price": 449900,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "movement": 2.2,
+          "time": "2d 2h",
+          "calcTime": 180000,
+          "price": 494900,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "movement": 2.3,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 544400,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "movement": 1.2,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 680500,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "movement": 1.2,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 850650,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "movement": 1.2,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1063300,
+          "diamonds": 1218
+        }
+      ],
+      "trucks": [
+        {
+          "level": 1,
+          "armor": 7,
+          "movement": 0.1,
+          "time": "1m",
+          "calcTime": 60,
+          "price": 600,
+          "diamonds": 1
+        },
+        {
+          "level": 2,
+          "armor": 7,
+          "movement": 0.2,
+          "time": "15m",
+          "calcTime": 900,
+          "price": 950,
+          "diamonds": 1
+        },
+        {
+          "level": 3,
+          "armor": 7,
+          "movement": 0.3,
+          "time": "1h",
+          "calcTime": 3600,
+          "price": 1550,
+          "diamonds": 4
+        },
+        {
+          "level": 4,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "3h",
+          "calcTime": 10800,
+          "price": 2500,
+          "diamonds": 8
+        },
+        {
+          "level": 5,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "3h 50m",
+          "calcTime": 13800,
+          "price": 4050,
+          "diamonds": 14
+        },
+        {
+          "level": 6,
+          "armor": 10,
+          "movement": 0.3,
+          "time": "8h",
+          "calcTime": 28800,
+          "price": 6100,
+          "diamonds": 18
+        },
+        {
+          "level": 7,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "10h 20m",
+          "calcTime": 37200,
+          "price": 9150,
+          "diamonds": 23
+        },
+        {
+          "level": 8,
+          "armor": 11,
+          "movement": 0.3,
+          "time": "13h",
+          "calcTime": 46800,
+          "price": 13750,
+          "diamonds": 28
+        },
+        {
+          "level": 9,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "15h 30m",
+          "calcTime": 55800,
+          "price": 20650,
+          "diamonds": 33
+        },
+        {
+          "level": 10,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "18h 20m",
+          "calcTime": 69600,
+          "price": 31000,
+          "diamonds": 39
+        },
+        {
+          "level": 11,
+          "armor": 14,
+          "movement": 0.5,
+          "time": "20h 50m",
+          "calcTime": 75000,
+          "price": 40300,
+          "diamonds": 44
+        },
+        {
+          "level": 12,
+          "armor": 14,
+          "movement": 0.4,
+          "time": "1d 10m",
+          "calcTime": 87000,
+          "price": 52400,
+          "diamonds": 51
+        },
+        {
+          "level": 13,
+          "armor": 17,
+          "movement": 0.5,
+          "time": "1d 3h",
+          "calcTime": 97200,
+          "price": 68100,
+          "diamonds": 70
+        },
+        {
+          "level": 14,
+          "armor": 18,
+          "movement": 0.6,
+          "time": "1d 6h",
+          "calcTime": 108000,
+          "price": 88550,
+          "diamonds": 85
+        },
+        {
+          "level": 15,
+          "armor": 17,
+          "movement": 0.6,
+          "time": "1d 9h 20m",
+          "calcTime": 120000,
+          "price": 115100,
+          "diamonds": 97
+        },
+        {
+          "level": 16,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 12h 40m",
+          "calcTime": 132000,
+          "price": 143900,
+          "diamonds": 114
+        },
+        {
+          "level": 17,
+          "armor": 21,
+          "movement": 0.6,
+          "time": "1d 16h",
+          "calcTime": 144000,
+          "price": 179900,
+          "diamonds": 130
+        },
+        {
+          "level": 18,
+          "armor": 25,
+          "movement": 0.7,
+          "time": "1d 19h 40m",
+          "calcTime": 157200,
+          "price": 224900,
+          "diamonds": 149
+        },
+        {
+          "level": 19,
+          "armor": 24,
+          "movement": 0.8,
+          "time": "1d 23h",
+          "calcTime": 169200,
+          "price": 281150,
+          "diamonds": 165
+        },
+        {
+          "level": 20,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 3h 40m",
+          "calcTime": 186000,
+          "price": 351450,
+          "diamonds": 258
+        },
+        {
+          "level": 21,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "2d 7h 30m",
+          "calcTime": 199800,
+          "price": 421750,
+          "diamonds": 350
+        },
+        {
+          "level": 22,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "2d 12h",
+          "calcTime": 216000,
+          "price": 506100,
+          "diamonds": 458
+        },
+        {
+          "level": 23,
+          "armor": 35,
+          "movement": 1,
+          "time": "1d 22h",
+          "calcTime": 165600,
+          "price": 607300,
+          "diamonds": 538
+        },
+        {
+          "level": 24,
+          "armor": 31,
+          "movement": 1.2,
+          "time": "2d 22h",
+          "calcTime": 252000,
+          "price": 728750,
+          "diamonds": 698
+        },
+        {
+          "level": 25,
+          "armor": 35,
+          "movement": 1.1,
+          "time": "3d 3h",
+          "calcTime": 270000,
+          "price": 874500,
+          "diamonds": 818
+        },
+        {
+          "level": 26,
+          "armor": 28,
+          "movement": 0.9,
+          "time": "3d 8h",
+          "calcTime": 288000,
+          "price": 966125,
+          "diamonds": 938
+        },
+        {
+          "level": 27,
+          "armor": 32,
+          "movement": 0.9,
+          "time": "3d 14h 40m",
+          "calcTime": 312000,
+          "price": 1078950,
+          "diamonds": 1098
+        },
+        {
+          "level": 28,
+          "armor": 35,
+          "movement": 1,
+          "time": "3d 19h 40m",
+          "calcTime": 330000,
+          "price": 1191755,
+          "diamonds": 1218
+        }
+      ],
+      "max": {
+        "allMax": {
+          "attack": 625,
+          "fireSpeed": 11.5,
+          "armor": 3043,
+          "movement": 86.1,
+          "levels": 28,
+          "totalPrice": 0,
+          "totalTime": 0,
+          "days": 0
+        },
+        "maxMovementFireSpeed": {
+          "attack": 364,
+          "fireSpeed": 15.4,
+          "armor": 1468,
+          "movement": 110.8
+        }
+      }
+    },
+    "S.SCORPIUS": {},
+    "PAVO": {},
+    "S.PAVO": {},
+    "MONOCEROS": {},
+    "S.MONOCEROS": {}
+  }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+struct TankUpgradeTotals: Equatable {
+    let totalTime: Int
+    let totalPrice: Int
+    let totalDiamonds: Int
+}
+
+final class TankCalculationService {
+    func setSelectLevelOptions(levels: Int) -> [Int] {
+        guard levels > 0 else { return [] }
+        return Array(1...levels)
+    }
+
+    func createTankStatData() -> UpgradeCalculatorState {
+        UpgradeCalculatorState(
+            version: UpgradeCalculatorState.currentVersion,
+            showTankLevels: false,
+            medalUsed: true,
+            tankLevels: UpgradeLevels(turretLevel: 0, barrelLevel: 0, armorLevel: 0, engineLevel: 0, trucksLevel: 0),
+            currentTankLevels: UpgradeLevels(turretLevel: 0, barrelLevel: 0, armorLevel: 0, engineLevel: 0, trucksLevel: 0),
+            tankStats: TankStats(attack: 0, fireSpeed: 0, armor: 0, movement: 0),
+            currentTankStats: TankStats(attack: 0, fireSpeed: 0, armor: 0, movement: 0),
+            tankUpgradeCostAndTime: UpgradeCost(price: 0, time: 0, displayTime: "0", diamonds: 0),
+            currentTankUpgradeCostAndTime: UpgradeCost(price: 0, time: 0, displayTime: "0", diamonds: 0),
+            timeAndCostFromCurrentToPotentialStats: UpgradeCost(price: 0, time: 0, displayTime: "0", diamonds: 0)
+        )
+    }
+
+    func calculateTankStats(tank: Tank, detail: TankDetail, levels: UpgradeLevels) -> TankStats {
+        let attack = calculatePotentialAttack(detail: detail, turretLevel: levels.turretLevel, barrelLevel: levels.barrelLevel) + tank.basicInfo.attack
+        let fireSpeed = calculatePotentialFireSpeed(detail: detail, turretLevel: levels.turretLevel, barrelLevel: levels.barrelLevel) + tank.basicInfo.fireSpeed
+        let armor = calculatePotentialArmor(detail: detail, armorLevel: levels.armorLevel, trucksLevel: levels.trucksLevel) + tank.basicInfo.armor
+        let movement = calculatePotentialMovement(detail: detail, armorLevel: levels.armorLevel, engineLevel: levels.engineLevel, trucksLevel: levels.trucksLevel) + tank.basicInfo.movement
+        return TankStats(attack: attack, fireSpeed: fireSpeed, armor: armor, movement: movement)
+    }
+
+    func calculateTimeAndPriceForTankStats(detail: TankDetail, levels: UpgradeLevels) -> TankUpgradeTotals {
+        let components: [(UpgradeLevels) -> Int, [UpgradeLevel]?] = [
+            ({ $0.turretLevel }, detail.turret),
+            ({ $0.barrelLevel }, detail.barrel),
+            ({ $0.armorLevel }, detail.armor),
+            ({ $0.engineLevel }, detail.engine),
+            ({ $0.trucksLevel }, detail.trucks)
+        ]
+
+        var totalTime = 0
+        var totalPrice = 0
+        var totalDiamonds = 0
+
+        for (levelKey, list) in components {
+            guard let upgrades = list else { continue }
+            let count = min(max(levelKey(levels), 0), upgrades.count)
+            guard count > 0 else { continue }
+            for upgrade in upgrades.prefix(count) {
+                totalTime += upgrade.calcTime ?? 0
+                totalPrice += upgrade.price ?? 0
+                totalDiamonds += upgrade.diamonds ?? 0
+            }
+        }
+
+        return TankUpgradeTotals(totalTime: totalTime, totalPrice: totalPrice, totalDiamonds: totalDiamonds)
+    }
+
+    func calculateTimeAndCostFromCurrentToPotential(_ state: inout UpgradeCalculatorState) {
+        let current = state.currentTankUpgradeCostAndTime
+        let potential = state.tankUpgradeCostAndTime
+        var delta = state.timeAndCostFromCurrentToPotentialStats
+
+        delta.time = max(potential.time - current.time, 0)
+        delta.diamonds = max(potential.diamonds - current.diamonds, 0)
+        delta.price = max(potential.price - current.price, 0)
+        delta.displayTime = formatTotalTime(delta.time)
+
+        state.timeAndCostFromCurrentToPotentialStats = delta
+    }
+
+    func formatTotalTime(_ time: Int) -> String {
+        guard time > 0 else { return "0" }
+        var remaining = time
+        let day = 86_400
+        let hour = 3_600
+        let minute = 60
+
+        let days = remaining / day
+        remaining -= days * day
+        let hours = remaining / hour
+        remaining -= hours * hour
+        let minutes = remaining / minute
+
+        var components: [String] = []
+        if days > 0 { components.append("\(days)d") }
+        if hours > 0 { components.append("\(hours)h") }
+        if minutes > 0 { components.append("\(minutes)m") }
+
+        return components.joined(separator: " ")
+    }
+
+    func calculateTotalTime(detail: TankDetail, levels: [Int]? = nil) -> Int {
+        calculateTotalValues(detail: detail, levels: levels, value: { $0.calcTime ?? 0 })
+    }
+
+    func calculateTotalPrice(detail: TankDetail, levels: [Int]? = nil) -> Int {
+        calculateTotalValues(detail: detail, levels: levels, value: { $0.price ?? 0 })
+    }
+
+    func calculateTotalDiamonds(detail: TankDetail, levels: [Int]? = nil) -> Int {
+        calculateTotalValues(detail: detail, levels: levels, value: { $0.diamonds ?? 0 })
+    }
+
+    func calculateTotalAttack(detail: TankDetail) -> Double {
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.attack ?? 0 })
+    }
+
+    func calculateTotalFireSpeed(detail: TankDetail) -> Double {
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.fireSpeed ?? 0 })
+    }
+
+    func calculateTotalArmor(detail: TankDetail) -> Double {
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.trucks], value: { $0.armor ?? 0 })
+    }
+
+    func calculateTotalMovement(detail: TankDetail) -> Double {
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.engine, \.trucks], value: { $0.movement ?? 0 })
+    }
+
+    private func calculatePotentialAttack(detail: TankDetail, turretLevel: Int, barrelLevel: Int) -> Double {
+        potentialValue(detail.turret, level: turretLevel, transform: { $0.attack }) +
+        potentialValue(detail.barrel, level: barrelLevel, transform: { $0.attack })
+    }
+
+    private func calculatePotentialFireSpeed(detail: TankDetail, turretLevel: Int, barrelLevel: Int) -> Double {
+        potentialValue(detail.turret, level: turretLevel, transform: { $0.fireSpeed }) +
+        potentialValue(detail.barrel, level: barrelLevel, transform: { $0.fireSpeed })
+    }
+
+    private func calculatePotentialArmor(detail: TankDetail, armorLevel: Int, trucksLevel: Int) -> Double {
+        potentialValue(detail.armor, level: armorLevel, transform: { $0.armor }) +
+        potentialValue(detail.trucks, level: trucksLevel, transform: { $0.armor })
+    }
+
+    private func calculatePotentialMovement(detail: TankDetail, armorLevel: Int, engineLevel: Int, trucksLevel: Int) -> Double {
+        potentialValue(detail.armor, level: armorLevel, transform: { $0.movement }) +
+        potentialValue(detail.engine, level: engineLevel, transform: { $0.movement }) +
+        potentialValue(detail.trucks, level: trucksLevel, transform: { $0.movement })
+    }
+
+    private func calculateTotalValues(detail: TankDetail, levels: [Int]? = nil, value: (UpgradeLevel) -> Int) -> Int {
+        let components: [([UpgradeLevel]?, Int?)] = [
+            (detail.turret, levels?.element(at: 0)),
+            (detail.barrel, levels?.element(at: 1)),
+            (detail.armor, levels?.element(at: 2)),
+            (detail.engine, levels?.element(at: 3)),
+            (detail.trucks, levels?.element(at: 4))
+        ]
+
+        var total = 0
+        for (upgrades, limit) in components {
+            guard let upgrades else { continue }
+            let count = min(max(limit ?? upgrades.count, 0), upgrades.count)
+            guard count > 0 else { continue }
+            total += upgrades.prefix(count).reduce(into: 0) { $0 += value($1) }
+        }
+        return total
+    }
+
+    private func calculateTotalValues(detail: TankDetail, levelKeyPaths: [KeyPath<TankDetail, [UpgradeLevel]? >], value: (UpgradeLevel) -> Double) -> Double {
+        var total = 0.0
+        for keyPath in levelKeyPaths {
+            guard let upgrades = detail[keyPath: keyPath] else { continue }
+            for upgrade in upgrades {
+                total += value(upgrade)
+            }
+        }
+        return total
+    }
+
+    private func potentialValue(_ upgrades: [UpgradeLevel]?, level: Int, transform: (UpgradeLevel) -> Double?) -> Double {
+        guard let upgrades else { return 0 }
+        let count = min(max(level, 0), upgrades.count)
+        guard count > 0 else { return 0 }
+        return upgrades.prefix(count).reduce(0) { partial, upgrade in
+            partial + (transform(upgrade) ?? 0)
+        }
+    }
+}
+
+private extension Array {
+    func element(at index: Int) -> Element? {
+        guard indices.contains(index) else { return nil }
+        return self[index]
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
@@ -109,19 +109,19 @@ final class TankCalculationService {
     }
 
     func calculateTotalAttack(detail: TankDetail) -> Double {
-        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.attack ?? 0 })
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.attack ?? 0.0 })
     }
 
     func calculateTotalFireSpeed(detail: TankDetail) -> Double {
-        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.fireSpeed ?? 0 })
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.turret, \.barrel], value: { $0.fireSpeed ?? 0.0 })
     }
 
     func calculateTotalArmor(detail: TankDetail) -> Double {
-        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.trucks], value: { $0.armor ?? 0 })
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.trucks], value: { $0.armor ?? 0.0 })
     }
 
     func calculateTotalMovement(detail: TankDetail) -> Double {
-        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.engine, \.trucks], value: { $0.movement ?? 0 })
+        calculateTotalValues(detail: detail, levelKeyPaths: [\.armor, \.engine, \.trucks], value: { $0.movement ?? 0.0 })
     }
 
     private func calculatePotentialAttack(detail: TankDetail, turretLevel: Int, barrelLevel: Int) -> Double {
@@ -164,7 +164,7 @@ final class TankCalculationService {
         return total
     }
 
-    private func calculateTotalValues(detail: TankDetail, levelKeyPaths: [KeyPath<TankDetail, [UpgradeLevel]?>>, value: (UpgradeLevel) -> Double) -> Double {
+    private func calculateTotalValues(detail: TankDetail, levelKeyPaths: [KeyPath<TankDetail, [UpgradeLevel]?>], value: (UpgradeLevel) -> Double) -> Double {
         var total = 0.0
         for keyPath in levelKeyPaths {
             guard let upgrades = detail[keyPath: keyPath] else { continue }

--- a/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Services/TankCalculationService.swift
@@ -36,7 +36,7 @@ final class TankCalculationService {
     }
 
     func calculateTimeAndPriceForTankStats(detail: TankDetail, levels: UpgradeLevels) -> TankUpgradeTotals {
-        let components: [(UpgradeLevels) -> Int, [UpgradeLevel]?] = [
+        let components: [((UpgradeLevels) -> Int, [UpgradeLevel]?)] = [
             ({ $0.turretLevel }, detail.turret),
             ({ $0.barrelLevel }, detail.barrel),
             ({ $0.armorLevel }, detail.armor),
@@ -164,7 +164,7 @@ final class TankCalculationService {
         return total
     }
 
-    private func calculateTotalValues(detail: TankDetail, levelKeyPaths: [KeyPath<TankDetail, [UpgradeLevel]? >], value: (UpgradeLevel) -> Double) -> Double {
+    private func calculateTotalValues(detail: TankDetail, levelKeyPaths: [KeyPath<TankDetail, [UpgradeLevel]?>>, value: (UpgradeLevel) -> Double) -> Double {
         var total = 0.0
         for keyPath in levelKeyPaths {
             guard let upgrades = detail[keyPath: keyPath] else { continue }

--- a/ios/IronForceUpgradeCalculatorApp/Services/TankDataService.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Services/TankDataService.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum TankDataServiceError: Error {
+    case resourceNotFound
+    case failedToDecode(Error)
+}
+
+final class TankDataService {
+    private lazy var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        return decoder
+    }()
+
+    func loadTanks() throws -> TankData {
+        guard let url = Bundle.main.url(forResource: "tanks", withExtension: "json") else {
+            throw TankDataServiceError.resourceNotFound
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try decoder.decode(TankData.self, from: data)
+        } catch {
+            throw TankDataServiceError.failedToDecode(error)
+        }
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Tests/CalculatorServiceTests.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Tests/CalculatorServiceTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import IronForceUpgradeCalculatorApp
+
+final class CalculatorServiceTests: XCTestCase {
+    private let service = TankCalculationService()
+
+    func testHydrusCalculationsMatchJavaScriptImplementation() throws {
+        let data = try loadTankData()
+        guard let tank = data.tanks.first(where: { $0.name == "HYDRUS" }),
+              let detail = data.tankDetails[tank.name] else {
+            XCTFail("Missing HYDRUS data")
+            return
+        }
+
+        let targetLevels = UpgradeLevels(turretLevel: 5, barrelLevel: 5, armorLevel: 5, engineLevel: 5, trucksLevel: 5)
+        let currentLevels = UpgradeLevels(turretLevel: 2, barrelLevel: 2, armorLevel: 2, engineLevel: 2, trucksLevel: 2)
+
+        let stats = service.calculateTankStats(tank: tank, detail: detail, levels: targetLevels)
+        XCTAssertEqual(stats.attack, 66, accuracy: 0.0001)
+        XCTAssertEqual(stats.fireSpeed, 13.3, accuracy: 0.0001)
+        XCTAssertEqual(stats.armor, 379, accuracy: 0.0001)
+        XCTAssertEqual(stats.movement, 62.2, accuracy: 0.0001)
+
+        let totalsTarget = service.calculateTimeAndPriceForTankStats(detail: detail, levels: targetLevels)
+        XCTAssertEqual(totalsTarget.totalTime, 145_800)
+        XCTAssertEqual(totalsTarget.totalPrice, 147_200)
+        XCTAssertEqual(totalsTarget.totalDiamonds, 140)
+
+        let totalsCurrent = service.calculateTimeAndPriceForTankStats(detail: detail, levels: currentLevels)
+        XCTAssertEqual(totalsCurrent.totalTime, 4_800)
+        XCTAssertEqual(totalsCurrent.totalPrice, 23_600)
+        XCTAssertEqual(totalsCurrent.totalDiamonds, 10)
+
+        var state = service.createTankStatData()
+        state.tankLevels = targetLevels
+        state.currentTankLevels = currentLevels
+        state.medalUsed = true
+
+        let adjustedTargetTime = Int(Double(totalsTarget.totalTime) * 0.75)
+        let adjustedCurrentTime = Int(Double(totalsCurrent.totalTime) * 0.75)
+
+        state.tankUpgradeCostAndTime = UpgradeCost(
+            price: totalsTarget.totalPrice,
+            time: adjustedTargetTime,
+            displayTime: service.formatTotalTime(adjustedTargetTime),
+            diamonds: totalsTarget.totalDiamonds
+        )
+
+        state.currentTankUpgradeCostAndTime = UpgradeCost(
+            price: totalsCurrent.totalPrice,
+            time: adjustedCurrentTime,
+            displayTime: service.formatTotalTime(adjustedCurrentTime),
+            diamonds: totalsCurrent.totalDiamonds
+        )
+
+        service.calculateTimeAndCostFromCurrentToPotential(&state)
+
+        XCTAssertEqual(state.timeAndCostFromCurrentToPotentialStats.price, 123_600)
+        XCTAssertEqual(state.timeAndCostFromCurrentToPotentialStats.time, 105_750)
+        XCTAssertEqual(state.timeAndCostFromCurrentToPotentialStats.diamonds, 130)
+        XCTAssertEqual(state.timeAndCostFromCurrentToPotentialStats.displayTime, "1d 5h 22m")
+    }
+
+    func testFormatTotalTimeProducesExpectedStrings() {
+        XCTAssertEqual(service.formatTotalTime(0), "0")
+        XCTAssertEqual(service.formatTotalTime(60), "1m")
+        XCTAssertEqual(service.formatTotalTime(3_600), "1h")
+        XCTAssertEqual(service.formatTotalTime(3_660), "1h 1m")
+        XCTAssertEqual(service.formatTotalTime(105_750), "1d 5h 22m")
+    }
+
+    private func loadTankData() throws -> TankData {
+        let bundle = Bundle(for: CalculatorServiceTests.self)
+        let decoder = JSONDecoder()
+
+        if let url = bundle.url(forResource: "tanks", withExtension: "json") {
+            let data = try Data(contentsOf: url)
+            return try decoder.decode(TankData.self, from: data)
+        }
+
+        guard let url = Bundle.main.url(forResource: "tanks", withExtension: "json") else {
+            throw NSError(domain: "CalculatorServiceTests", code: 0, userInfo: [NSLocalizedDescriptionKey: "Unable to locate tanks.json"])
+        }
+
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(TankData.self, from: data)
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/ViewModels/TankDetailViewModel.swift
+++ b/ios/IronForceUpgradeCalculatorApp/ViewModels/TankDetailViewModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+enum UpgradeComponent: String, CaseIterable, Identifiable {
+    case turret
+    case barrel
+    case armor
+    case engine
+    case trucks
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        rawValue.capitalized
+    }
+}
+
+@MainActor
+final class TankDetailViewModel: ObservableObject {
+    @Published private(set) var calculatorState: UpgradeCalculatorState
+    @Published private(set) var selectLevelOptions: [Int]
+
+    let tank: Tank
+    let tankDetail: TankDetail
+
+    private let store: UserDefaultsStore
+    private let calculatorService: TankCalculationService
+
+    init(tank: Tank, tankDetail: TankDetail, store: UserDefaultsStore, calculatorService: TankCalculationService) {
+        self.tank = tank
+        self.tankDetail = tankDetail
+        self.store = store
+        self.calculatorService = calculatorService
+
+        store.selectedTank = tank.name
+
+        if let stored = store.loadCalculatorState(forTank: tank.name), stored.version == UpgradeCalculatorState.currentVersion {
+            calculatorState = stored
+        } else {
+            calculatorState = calculatorService.createTankStatData()
+        }
+
+        selectLevelOptions = calculatorService.setSelectLevelOptions(levels: tankDetail.turret?.count ?? 0)
+        recalculateAll()
+    }
+
+    func toggleMedalUsed(_ value: Bool) {
+        calculatorState.medalUsed = value
+        recalculateAll()
+    }
+
+    func toggleShowTankLevels(_ value: Bool) {
+        calculatorState.showTankLevels = value
+        persistState()
+    }
+
+    func updateLevel(_ component: UpgradeComponent, isCurrent: Bool, to level: Int) {
+        var levels = isCurrent ? calculatorState.currentTankLevels : calculatorState.tankLevels
+
+        switch component {
+        case .turret:
+            levels.turretLevel = level
+        case .barrel:
+            levels.barrelLevel = level
+        case .armor:
+            levels.armorLevel = level
+        case .engine:
+            levels.engineLevel = level
+        case .trucks:
+            levels.trucksLevel = level
+        }
+
+        if isCurrent {
+            calculatorState.currentTankLevels = levels
+        } else {
+            calculatorState.tankLevels = levels
+        }
+
+        recalculateAll()
+    }
+
+    private func recalculateAll() {
+        calculatorState.tankStats = calculatorService.calculateTankStats(tank: tank, detail: tankDetail, levels: calculatorState.tankLevels)
+        calculatorState.currentTankStats = calculatorService.calculateTankStats(tank: tank, detail: tankDetail, levels: calculatorState.currentTankLevels)
+
+        let potentialTotals = calculatorService.calculateTimeAndPriceForTankStats(detail: tankDetail, levels: calculatorState.tankLevels)
+        calculatorState.tankUpgradeCostAndTime = createCost(from: potentialTotals)
+
+        let currentTotals = calculatorService.calculateTimeAndPriceForTankStats(detail: tankDetail, levels: calculatorState.currentTankLevels)
+        calculatorState.currentTankUpgradeCostAndTime = createCost(from: currentTotals)
+
+        calculatorService.calculateTimeAndCostFromCurrentToPotential(&calculatorState)
+        persistState()
+    }
+
+    private func createCost(from totals: TankUpgradeTotals) -> UpgradeCost {
+        let multiplier = calculatorState.medalUsed ? 0.75 : 1.0
+        let adjustedTime = Int(Double(totals.totalTime) * multiplier)
+        let displayTime = calculatorService.formatTotalTime(adjustedTime)
+        return UpgradeCost(price: totals.totalPrice, time: adjustedTime, displayTime: displayTime, diamonds: totals.totalDiamonds)
+    }
+
+    private func persistState() {
+        store.saveCalculatorState(calculatorState, forTank: tank.name)
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/ViewModels/TankListViewModel.swift
+++ b/ios/IronForceUpgradeCalculatorApp/ViewModels/TankListViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@MainActor
+final class TankListViewModel: ObservableObject {
+    @Published private(set) var tanks: [Tank] = []
+    @Published var errorMessage: String?
+
+    private let dataService: TankDataService
+    private let store: UserDefaultsStore
+    private let calculatorService: TankCalculationService
+
+    private var tankData: TankData?
+
+    init(dataService: TankDataService, store: UserDefaultsStore, calculatorService: TankCalculationService) {
+        self.dataService = dataService
+        self.store = store
+        self.calculatorService = calculatorService
+        load()
+    }
+
+    func load() {
+        do {
+            let data = try dataService.loadTanks()
+            tankData = data
+            tanks = data.tanks
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func detailViewModel(for tank: Tank) -> TankDetailViewModel? {
+        guard let data = tankData, let detail = data.tankDetails[tank.name] else { return nil }
+        return TankDetailViewModel(
+            tank: tank,
+            tankDetail: detail,
+            store: store,
+            calculatorService: calculatorService
+        )
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Views/Components/CostSummaryView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/Components/CostSummaryView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct CostSummaryView: View {
+    let title: String
+    let cost: UpgradeCost
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            HStack {
+                CostValueView(label: "Price", value: cost.price.formatted(.number))
+                Spacer()
+                CostValueView(label: "Diamonds", value: cost.diamonds.formatted())
+            }
+            CostValueView(label: "Time", value: cost.displayTime)
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+private struct CostValueView: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.body)
+                .bold()
+        }
+    }
+}
+
+#Preview
+struct CostSummaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        CostSummaryView(title: "Total Cost", cost: UpgradeCost(price: 147200, time: 109350, displayTime: "1d 6h", diamonds: 140))
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Views/Components/CostSummaryView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/Components/CostSummaryView.swift
@@ -36,7 +36,6 @@ private struct CostValueView: View {
     }
 }
 
-#Preview
 struct CostSummaryView_Previews: PreviewProvider {
     static var previews: some View {
         CostSummaryView(title: "Total Cost", cost: UpgradeCost(price: 147200, time: 109350, displayTime: "1d 6h", diamonds: 140))

--- a/ios/IronForceUpgradeCalculatorApp/Views/Components/StatBlockView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/Components/StatBlockView.swift
@@ -40,7 +40,6 @@ private struct StatValueView: View {
     }
 }
 
-#Preview
 struct StatBlockView_Previews: PreviewProvider {
     static var previews: some View {
         StatBlockView(

--- a/ios/IronForceUpgradeCalculatorApp/Views/Components/StatBlockView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/Components/StatBlockView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct StatBlockView: View {
+    let title: String
+    let stats: TankStats
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            HStack {
+                StatValueView(label: "Attack", value: stats.attack)
+                Spacer()
+                StatValueView(label: "Fire Speed", value: stats.fireSpeed)
+            }
+            HStack {
+                StatValueView(label: "Armor", value: stats.armor)
+                Spacer()
+                StatValueView(label: "Movement", value: stats.movement)
+            }
+        }
+        .padding()
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+private struct StatValueView: View {
+    let label: String
+    let value: Double
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value.formatted(.number.precision(.fractionLength(0...1))))
+                .font(.title3)
+                .bold()
+        }
+    }
+}
+
+#Preview
+struct StatBlockView_Previews: PreviewProvider {
+    static var previews: some View {
+        StatBlockView(
+            title: "Potential Stats",
+            stats: TankStats(attack: 120, fireSpeed: 11.2, armor: 450, movement: 60)
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Views/LevelPickerSheet.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/LevelPickerSheet.swift
@@ -43,7 +43,6 @@ struct LevelPickerSheet: View {
     }
 }
 
-#Preview
 struct LevelPickerSheet_Previews: PreviewProvider {
     static var previews: some View {
         LevelPickerSheet(title: "Turret Level", availableLevels: Array(0...5), initialValue: 2) { _ in }

--- a/ios/IronForceUpgradeCalculatorApp/Views/LevelPickerSheet.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/LevelPickerSheet.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct LevelPickerSheet: View {
+    let title: String
+    let availableLevels: [Int]
+    let initialValue: Int
+    let onSelection: (Int) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selection: Int
+
+    init(title: String, availableLevels: [Int], initialValue: Int, onSelection: @escaping (Int) -> Void) {
+        self.title = title
+        self.availableLevels = availableLevels
+        self.initialValue = initialValue
+        self.onSelection = onSelection
+        _selection = State(initialValue: initialValue)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Picker("Level", selection: $selection) {
+                    ForEach(availableLevels, id: \.self) { level in
+                        Text(String(level)).tag(level)
+                    }
+                }
+                .pickerStyle(.wheel)
+            }
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        onSelection(selection)
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview
+struct LevelPickerSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        LevelPickerSheet(title: "Turret Level", availableLevels: Array(0...5), initialValue: 2) { _ in }
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Views/TankDetailView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/TankDetailView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct TankDetailView: View {
+    @StateObject private var viewModel: TankDetailViewModel
+    @State private var activeSelection: LevelSelection?
+
+    init(viewModel: TankDetailViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                medalToggle
+                showLevelsToggle
+                if viewModel.calculatorState.showTankLevels {
+                    levelSection(title: "Potential Levels", isCurrent: false)
+                }
+                levelSection(title: "Current Levels", isCurrent: true)
+                StatBlockView(title: "Potential Stats", stats: viewModel.calculatorState.tankStats)
+                StatBlockView(title: "Current Stats", stats: viewModel.calculatorState.currentTankStats)
+                CostSummaryView(title: "Potential Cost", cost: viewModel.calculatorState.tankUpgradeCostAndTime)
+                CostSummaryView(title: "Current Cost", cost: viewModel.calculatorState.currentTankUpgradeCostAndTime)
+                CostSummaryView(title: "Difference", cost: viewModel.calculatorState.timeAndCostFromCurrentToPotentialStats)
+            }
+            .padding()
+        }
+        .navigationTitle(viewModel.tank.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $activeSelection) { selection in
+            LevelPickerSheet(
+                title: "\(selection.isCurrent ? "Current" : "Potential") \(selection.component.displayName)",
+                availableLevels: levelOptions,
+                initialValue: level(for: selection.component, isCurrent: selection.isCurrent)
+            ) { newValue in
+                viewModel.updateLevel(selection.component, isCurrent: selection.isCurrent, to: newValue)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(viewModel.tank.name)
+                .font(.largeTitle)
+                .bold()
+            Text("Tier \(viewModel.tank.tier)")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 16) {
+                StatValue(label: "Base Attack", value: viewModel.tank.basicInfo.attack)
+                StatValue(label: "Base Armor", value: viewModel.tank.basicInfo.armor)
+            }
+            HStack(spacing: 16) {
+                StatValue(label: "Base Fire Speed", value: viewModel.tank.basicInfo.fireSpeed)
+                StatValue(label: "Base Movement", value: viewModel.tank.basicInfo.movement)
+            }
+        }
+    }
+
+    private var medalToggle: some View {
+        Toggle(
+            "Medal Applied",
+            isOn: Binding(
+                get: { viewModel.calculatorState.medalUsed },
+                set: { viewModel.toggleMedalUsed($0) }
+            )
+        )
+    }
+
+    private var showLevelsToggle: some View {
+        Toggle(
+            "Show Potential Levels",
+            isOn: Binding(
+                get: { viewModel.calculatorState.showTankLevels },
+                set: { viewModel.toggleShowTankLevels($0) }
+            )
+        )
+    }
+
+    private func levelSection(title: String, isCurrent: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            ForEach(UpgradeComponent.allCases) { component in
+                LevelRow(
+                    label: component.displayName,
+                    value: level(for: component, isCurrent: isCurrent)
+                ) {
+                    activeSelection = LevelSelection(component: component, isCurrent: isCurrent)
+                }
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func level(for component: UpgradeComponent, isCurrent: Bool) -> Int {
+        let levels = isCurrent ? viewModel.calculatorState.currentTankLevels : viewModel.calculatorState.tankLevels
+        switch component {
+        case .turret:
+            return levels.turretLevel
+        case .barrel:
+            return levels.barrelLevel
+        case .armor:
+            return levels.armorLevel
+        case .engine:
+            return levels.engineLevel
+        case .trucks:
+            return levels.trucksLevel
+        }
+    }
+
+    private var levelOptions: [Int] {
+        var options = viewModel.selectLevelOptions
+        options.insert(0, at: 0)
+        return options
+    }
+}
+
+private struct LevelRow: View {
+    let label: String
+    let value: Int
+    let onTap: () -> Void
+
+    var body: some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Button(action: onTap) {
+                Text("Level \(value)")
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+private struct LevelSelection: Identifiable {
+    let component: UpgradeComponent
+    let isCurrent: Bool
+    let id = UUID()
+}
+
+private struct StatValue: View {
+    let label: String
+    let value: Double
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value.formatted(.number.precision(.fractionLength(0...1))))
+                .font(.headline)
+        }
+    }
+}
+
+#Preview
+struct TankDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            if let data = try? TankDataService().loadTanks(),
+               let tank = data.tanks.first,
+               let detail = data.tankDetails[tank.name] {
+                TankDetailView(viewModel: TankDetailViewModel(
+                    tank: tank,
+                    tankDetail: detail,
+                    store: UserDefaultsStore(userDefaults: UserDefaults(suiteName: "Preview") ?? .standard),
+                    calculatorService: TankCalculationService()
+                ))
+            } else {
+                Text("Preview unavailable")
+            }
+        }
+    }
+}

--- a/ios/IronForceUpgradeCalculatorApp/Views/TankDetailView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/TankDetailView.swift
@@ -156,7 +156,6 @@ private struct StatValue: View {
     }
 }
 
-#Preview
 struct TankDetailView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {

--- a/ios/IronForceUpgradeCalculatorApp/Views/TankListView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/TankListView.swift
@@ -59,7 +59,6 @@ private struct TankRowView: View {
     }
 }
 
-#Preview
 struct TankListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {

--- a/ios/IronForceUpgradeCalculatorApp/Views/TankListView.swift
+++ b/ios/IronForceUpgradeCalculatorApp/Views/TankListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct TankListView: View {
+    @StateObject private var viewModel: TankListViewModel
+
+    init(viewModel: TankListViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        List(viewModel.tanks) { tank in
+            NavigationLink(value: tank) {
+                TankRowView(tank: tank)
+            }
+        }
+        .navigationTitle("Tanks")
+        .navigationDestination(for: Tank.self) { tank in
+            if let detailViewModel = viewModel.detailViewModel(for: tank) {
+                TankDetailView(viewModel: detailViewModel)
+            } else {
+                Text("Unable to load details")
+            }
+        }
+        .overlay(alignment: .center) {
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .multilineTextAlignment(.center)
+                    .padding()
+            }
+        }
+    }
+}
+
+private struct TankRowView: View {
+    let tank: Tank
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tank.name)
+                    .font(.headline)
+                Text("Tier \(tank.tier)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(tank.price)
+                    .font(.subheadline)
+                if !tank.payType.isEmpty {
+                    Text(tank.payType)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview
+struct TankListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            TankListView(viewModel: TankListViewModel(
+                dataService: TankDataService(),
+                store: UserDefaultsStore(userDefaults: UserDefaults(suiteName: "Preview") ?? .standard),
+                calculatorService: TankCalculationService()
+            ))
+        }
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,6 @@
+# IronForceUpgradeCalculatorApp (iOS)
+
+1. Open `ios/IronForceUpgradeCalculatorApp.xcodeproj` in Xcode 15 or later.
+2. Select the **IronForceUpgradeCalculatorApp** scheme and choose an iOS 16+ simulator or device.
+3. Build and run to launch the SwiftUI NavigationStack-based experience.
+4. Execute the unit tests via **Product ▸ Test** (⌘U) to validate the calculator service logic.


### PR DESCRIPTION
## Summary
- add an iOS SwiftUI app project seeded with the converted tank dataset and persistence helpers
- implement calculator services, view models, and SwiftUI views that mirror the original Angular upgrade calculator
- include unit tests for the calculation service and document how to build the new target

## Testing
- not run (requires Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68f36cdf0058832f88422cd9e079c433